### PR TITLE
Refactor project framework handling: single framework association

### DIFF
--- a/app/Http/Controllers/User/ProjectController.php
+++ b/app/Http/Controllers/User/ProjectController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\User;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\AddFrameworksToProject;
+use App\Http\Requests\AddFrameworkToProject;
 use App\Http\Requests\AddMemberToProjectRequest;
 use App\Http\Requests\SearchProjectsRequest;
 use App\Repositories\ProjectRepository;
@@ -68,16 +68,16 @@ class ProjectController extends Controller
         ]);
     }
 
-    public function addFrameworks(AddFrameworksToProject $request, Project $project): JsonResponse
+    public function addFramework(AddFrameworkToProject $request, Project $project): JsonResponse
     {
         $validated = $request->validated();
 
-        $this->projectRepository->addFrameworksToProject($project, $validated['framework_ids']);
+        $this->projectRepository->addFrameworkToProject($project, $validated['framework_id']);
 
         return response()->json([
             'data' => null,
             'error' => false,
-            'message' => 'Frameworks added to project successfully',
+            'message' => 'Framework added to project successfully',
         ]);
     }
 }

--- a/app/Http/Requests/AddFrameworkToProject.php
+++ b/app/Http/Requests/AddFrameworkToProject.php
@@ -4,7 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 
-class AddFrameworksToProject extends FormRequest
+class AddFrameworkToProject extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -22,8 +22,7 @@ class AddFrameworksToProject extends FormRequest
     public function rules(): array
     {
         return [
-            'framework_ids' => ['required', 'array'],
-            'framework_ids.*' => ['exists:frameworks,id'],
+            'framework_id' => ['required', 'integer', 'exists:frameworks,id'],
         ];
     }
 }

--- a/app/Http/Resources/ProjectResource.php
+++ b/app/Http/Resources/ProjectResource.php
@@ -26,10 +26,12 @@ class ProjectResource extends JsonResource
             'progress' => $this->progress,
             'created_at' => $this->created_at->toDateTimeString(),
             'updated_at' => $this->updated_at->toDateTimeString(),
-            'total_requirements' => $this->total_requirements,
-            'total_controls' => $this->total_controls,
+            'total_requirements' => $this->framework->requirements_count
+                ?? ($this->framework->relationLoaded('requirements') ? $this->framework->requirements->count() : 0),
+            'total_controls' => $this->framework->controls_count
+                ?? ($this->framework->relationLoaded('controls') ? $this->framework->controls->count() : 0),
             'users' => UserResource::collection($this->whenLoaded('users')),
-            'frameworks' => FrameworkResource::collection($this->whenLoaded('frameworks')),
+            'framework' => new FrameworkResource($this->whenLoaded('framework')),
         ];
     }
 }

--- a/app/Http/Resources/ProjectResource.php
+++ b/app/Http/Resources/ProjectResource.php
@@ -18,6 +18,18 @@ class ProjectResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        $framework = $this->framework;
+
+        $totalRequirements = 0;
+        $totalControls = 0;
+
+        if ($framework) {
+            $totalRequirements = $framework->requirements_count
+                ?? ($framework->relationLoaded('requirements') ? $framework->requirements->count() : 0);
+            $totalControls = $framework->controls_count
+                ?? ($framework->relationLoaded('controls') ? $framework->controls->count() : 0);
+        }
+
         return [
             'id' => $this->id,
             'name' => $this->name,
@@ -26,12 +38,10 @@ class ProjectResource extends JsonResource
             'progress' => $this->progress,
             'created_at' => $this->created_at->toDateTimeString(),
             'updated_at' => $this->updated_at->toDateTimeString(),
-            'total_requirements' => $this->framework->requirements_count
-                ?? ($this->framework->relationLoaded('requirements') ? $this->framework->requirements->count() : 0),
-            'total_controls' => $this->framework->controls_count
-                ?? ($this->framework->relationLoaded('controls') ? $this->framework->controls->count() : 0),
+            'total_requirements' => $totalRequirements,
+            'total_controls' => $totalControls,
             'users' => UserResource::collection($this->whenLoaded('users')),
-            'framework' => new FrameworkResource($this->whenLoaded('framework')),
+            'framework' => $framework ? new FrameworkResource($this->whenLoaded('framework')) : null,
         ];
     }
 }

--- a/app/Http/Resources/ProjectResource.php
+++ b/app/Http/Resources/ProjectResource.php
@@ -18,17 +18,7 @@ class ProjectResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
-        $framework = $this->framework;
-
-        $totalRequirements = 0;
-        $totalControls = 0;
-
-        if ($framework) {
-            $totalRequirements = $framework->requirements_count
-                ?? ($framework->relationLoaded('requirements') ? $framework->requirements->count() : 0);
-            $totalControls = $framework->controls_count
-                ?? ($framework->relationLoaded('controls') ? $framework->controls->count() : 0);
-        }
+        $frameworkCounts = $this->getFrameworkCounts();
 
         return [
             'id' => $this->id,
@@ -38,10 +28,38 @@ class ProjectResource extends JsonResource
             'progress' => $this->progress,
             'created_at' => $this->created_at->toDateTimeString(),
             'updated_at' => $this->updated_at->toDateTimeString(),
-            'total_requirements' => $totalRequirements,
-            'total_controls' => $totalControls,
+            'total_requirements' => $frameworkCounts['requirements'],
+            'total_controls' => $frameworkCounts['controls'],
             'users' => ProjectMemberResource::collection($this->whenLoaded('users')),
-            'framework' => $framework ? new FrameworkResource($this->whenLoaded('framework')) : null,
+            'framework' => $this->framework ? new FrameworkResource($this->whenLoaded('framework')) : null,
+        ];
+    }
+
+    /**
+     * Get the framework requirements and controls counts.
+     *
+     * @return array<string, int>
+     */
+    private function getFrameworkCounts(): array
+    {
+        $framework = $this->framework;
+
+        if (!$framework) {
+            return [
+                'requirements' => 0,
+                'controls' => 0,
+            ];
+        }
+
+        $requirements = $framework->requirements_count
+            ?? ($framework->relationLoaded('requirements') ? $framework->requirements->count() : 0);
+
+        $controls = $framework->controls_count
+            ?? ($framework->relationLoaded('controls') ? $framework->controls->count() : 0);
+
+        return [
+            'requirements' => $requirements,
+            'controls' => $controls,
         ];
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -4,8 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Validation\Rules\In;
 
 class Project extends Model
 {
@@ -13,8 +13,6 @@ class Project extends Model
     use HasFactory;
 
     protected $fillable = ['name', 'description', 'governance_pillar', 'progress'];
-
-    protected $appends = ['total_requirements', 'total_controls'];
 
     /**
      * The users that belong to the project.
@@ -27,36 +25,12 @@ class Project extends Model
     }
 
     /**
-     * The frameworks that belong to the project.
+     * The framework that belong to the project.
      *
-     * @return BelongsToMany<Framework, $this>
+     * @return BelongsTo<Framework, $this>
      */
-    public function frameworks(): BelongsToMany
+    public function framework(): BelongsTo
     {
-        return $this->belongsToMany(Framework::class);
-    }
-
-    /**
-     * Get the total number of requirements across all frameworks in the project.
-     *
-     * @return int
-     */
-    public function getTotalRequirementsAttribute(): int
-    {
-        return $this->frameworks->sum(function ($framework) {
-            return $framework->requirements->count();
-        });
-    }
-
-    /**
-     * Get the total number of controls across all frameworks in the project.
-     *
-     * @return int
-     */
-    public function getTotalControlsAttribute(): int
-    {
-        return $this->frameworks->sum(function ($framework) {
-            return $framework->controls->count();
-        });
+        return $this->belongsTo(Framework::class);
     }
 }

--- a/app/Repositories/ProjectRepository.php
+++ b/app/Repositories/ProjectRepository.php
@@ -20,7 +20,7 @@ class ProjectRepository
     {
         $query = Project::whereHas('users', function ($q) use ($userID) {
             $q->where('user_id', $userID);
-        })->with('users', 'frameworks')->withCount('users', 'frameworks');
+        })->with('users', 'framework')->withCount('users', 'framework');
 
         $query->when(! empty($filters['name']), function ($query) use ($filters) {
             $query->where('name', 'like', '%' . $filters['name'] . '%');
@@ -37,7 +37,12 @@ class ProjectRepository
 
     public function getProjectByID(Project $project): Project
     {
-        $project->load('users', 'frameworks.requirements', 'frameworks.controls');
+        $project->load([
+            'users',
+            'framework' => function ($query) {
+                $query->withCount(['requirements', 'controls']);
+            }
+        ]);
         return $project;
     }
 
@@ -57,9 +62,10 @@ class ProjectRepository
         return $project;
     }
 
-    public function addFrameworksToProject(Project $project, array $frameworkIDs): Project
+    public function addFrameworkToProject(Project $project, int $frameworkID): Project
     {
-        $project->frameworks()->syncWithoutDetaching($frameworkIDs);
+        $project->framework_id = $frameworkID;
+        $project->save();
 
         return $project;
     }

--- a/database/factories/ProjectFactory.php
+++ b/database/factories/ProjectFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Enums\GovernancePillar;
+use App\Models\Framework;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -19,6 +20,7 @@ class ProjectFactory extends Factory
     {
         return [
             'name' => $this->faker->sentence(3),
+            'framework_id' => Framework::factory(),
             'description' => $this->faker->paragraph,
             'governance_pillar' => $this->faker->randomElement(GovernancePillar::cases()),
             'progress' => $this->faker->numberBetween(0, 100),

--- a/database/migrations/2025_09_25_125647_add_framework_id_column_to_projects_table.php
+++ b/database/migrations/2025_09_25_125647_add_framework_id_column_to_projects_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Models\Framework;
+use App\Models\Project;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::dropIfExists('framework_project');
+
+        Schema::table('projects', function (Blueprint $table) {
+            $table->foreignIdFor(Framework::class)->nullable()->constrained()->onDelete('set null')->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('projects', function (Blueprint $table) {
+            $table->dropForeign(['framework_id']);
+            $table->dropColumn('framework_id');
+        });
+
+        Schema::create('framework_project', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(Framework::class)->constrained()->onDelete('cascade');
+            $table->foreignIdFor(Project::class)->constrained()->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+};

--- a/routes/api/user.php
+++ b/routes/api/user.php
@@ -51,7 +51,7 @@ Route::middleware(['auth:supabase'])->group(function () {
         Route::post('', 'store');
         Route::get('{project}', 'show');
         Route::post('{project}/add-member', 'addMember')->can('addMember', 'project');
-        Route::post('{project}/add-frameworks', 'addFrameworks');
+        Route::post('{project}/add-framework', 'addFramework');
     });
 
     Route::prefix('ai-models')->controller(AiController::class)->group(function () {

--- a/tests/Feature/Controllers/User/ProjectControllerTest.php
+++ b/tests/Feature/Controllers/User/ProjectControllerTest.php
@@ -21,21 +21,23 @@ class ProjectControllerTest extends TestCase
     {
         $user = User::factory()->create();
         $this->actingAs($user);
-        $project = Project::factory()->create();
-        $project->users()->attach($user->id, ['role' => UserProjectRole::OWNER]);
-        $framework1 = Framework::factory()->create();
-        $framework2 = Framework::factory()->create();
-        $project->frameworks()->attach([$framework1->id, $framework2->id]);
+
+        $framework = Framework::factory()->create();
 
         $requirements1 = Requirement::factory()->count(2)->create();
         $requirements2 = Requirement::factory()->count(3)->create();
-        $framework1->requirements()->attach($requirements1->pluck('id'));
-        $framework2->requirements()->attach($requirements2->pluck('id'));
+        $framework->requirements()->attach($requirements1->pluck('id'));
+        $framework->requirements()->attach($requirements2->pluck('id'));
 
         $controls1 = Control::factory()->count(1)->create();
         $controls2 = Control::factory()->count(4)->create();
-        $framework1->controls()->attach($controls1->pluck('id'));
-        $framework2->controls()->attach($controls2->pluck('id'));
+        $framework->controls()->attach($controls1->pluck('id'));
+        $framework->controls()->attach($controls2->pluck('id'));
+
+        $project = Project::factory()->create([
+            'framework_id' => $framework->id,
+        ]);
+        $project->users()->attach($user->id, ['role' => UserProjectRole::OWNER]);
 
         $response = $this->getJson("/api/projects/{$project->id}");
         $response->assertOk();
@@ -48,13 +50,9 @@ class ProjectControllerTest extends TestCase
                 'progress',
                 'total_requirements',
                 'total_controls',
-                'frameworks' => [
-                    '*' => [
-                        'id',
-                        'name',
-                        'requirements',
-                        'controls',
-                    ],
+                'framework' => [
+                    'id',
+                    'name',
                 ],
             ],
         ]);
@@ -124,23 +122,21 @@ class ProjectControllerTest extends TestCase
         $this->assertDatabaseHas('project_user', ['user_id' => $newMember->id, 'role' => UserProjectRole::EDITOR]);
     }
 
-    public function test_user_can_add_frameworks_to_project(): void
+    public function test_user_can_add_framework_to_project(): void
     {
         $user = User::factory()->create();
         $this->actingAs($user);
         $project = Project::factory()->create();
         $project->users()->attach($user->id, ['role' => UserProjectRole::OWNER]);
 
-        $frameworks = Framework::factory()->count(2)->create();
-        $frameworkIDs = $frameworks->pluck('id')->toArray();
-        $data = ['framework_ids' => $frameworkIDs];
+        $framework = Framework::factory()->create();
 
-        $response = $this->postJson("/api/projects/{$project->id}/add-frameworks", $data);
+        $data = ['framework_id' => $framework->id];
+
+        $response = $this->postJson("/api/projects/{$project->id}/add-framework", $data);
         $response->assertOk();
-        $response->assertJson(['error' => false, 'message' => 'Frameworks added to project successfully']);
-        foreach ($frameworkIDs as $fwID) {
-            $this->assertDatabaseHas('framework_project', ['project_id' => $project->id, 'framework_id' => $fwID]);
-        }
+        $response->assertJson(['error' => false, 'message' => 'Framework added to project successfully']);
+        $this->assertDatabaseHas('projects', ['id' => $project->id, 'framework_id' => $framework->id]);
     }
 
     public function test_non_owner_cannot_add_a_new_member(): void

--- a/tests/Feature/Controllers/User/ProjectControllerTest.php
+++ b/tests/Feature/Controllers/User/ProjectControllerTest.php
@@ -41,6 +41,8 @@ class ProjectControllerTest extends TestCase
 
         $response = $this->getJson("/api/projects/{$project->id}");
         $response->assertOk();
+        $response->assertJsonPath('data.total_requirements', 5);
+        $response->assertJsonPath('data.total_controls', 5);
         $response->assertJsonStructure([
             'data' => [
                 'id',

--- a/tests/Feature/Repositories/ProjectRepositoryTest.php
+++ b/tests/Feature/Repositories/ProjectRepositoryTest.php
@@ -62,7 +62,10 @@ class ProjectRepositoryTest extends TestCase
 
     public function test_it_get_project_by_id_with_framework_but_no_requirements_or_controls(): void
     {
-        $project = Project::factory()->create();
+        $framework = Framework::factory()->create();
+        $project = Project::factory()->create([
+            'framework_id' => $framework->id,
+        ]);
         $result = $this->projectRepository->getProjectByID($project);
         $this->assertEquals(0, $result->total_requirements);
         $this->assertEquals(0, $result->total_controls);

--- a/tests/Feature/Repositories/ProjectRepositoryTest.php
+++ b/tests/Feature/Repositories/ProjectRepositoryTest.php
@@ -28,27 +28,31 @@ class ProjectRepositoryTest extends TestCase
 
     public function test_it_get_project_by_id(): void
     {
-        $project = Project::factory()->create();
-        $framework1 = Framework::factory()->create();
-        $framework2 = Framework::factory()->create();
-        $project->frameworks()->attach([$framework1->id, $framework2->id]);
+
+        $framework = Framework::factory()->create();
+
 
         $requirements1 = Requirement::factory()->count(2)->create();
         $requirements2 = Requirement::factory()->count(3)->create();
-        $framework1->requirements()->attach($requirements1->pluck('id'));
-        $framework2->requirements()->attach($requirements2->pluck('id'));
+        $framework->requirements()->attach($requirements1->pluck('id'));
+        $framework->requirements()->attach($requirements2->pluck('id'));
 
         $controls1 = Control::factory()->count(1)->create();
         $controls2 = Control::factory()->count(4)->create();
-        $framework1->controls()->attach($controls1->pluck('id'));
-        $framework2->controls()->attach($controls2->pluck('id'));
+        $framework->controls()->attach($controls1->pluck('id'));
+        $framework->controls()->attach($controls2->pluck('id'));
+
+        $project = Project::factory()->create([
+            'framework_id' => $framework->id,
+        ]);
+
 
         $result = $this->projectRepository->getProjectByID($project);
-        $this->assertEquals(5, $result->total_requirements);
-        $this->assertEquals(5, $result->total_controls);
+        $this->assertEquals(5, $result->framework->requirements_count);
+        $this->assertEquals(5, $result->framework->controls_count);
     }
 
-    public function test_it_get_project_by_id_with_no_frameworks(): void
+    public function test_it_get_project_by_id_with_no_framework(): void
     {
         $project = Project::factory()->create();
         $result = $this->projectRepository->getProjectByID($project);
@@ -56,11 +60,9 @@ class ProjectRepositoryTest extends TestCase
         $this->assertEquals(0, $result->total_controls);
     }
 
-    public function test_it_get_project_by_id_with_frameworks_but_no_requirements_or_controls(): void
+    public function test_it_get_project_by_id_with_framework_but_no_requirements_or_controls(): void
     {
         $project = Project::factory()->create();
-        $framework = Framework::factory()->create();
-        $project->frameworks()->attach($framework->id);
         $result = $this->projectRepository->getProjectByID($project);
         $this->assertEquals(0, $result->total_requirements);
         $this->assertEquals(0, $result->total_controls);
@@ -134,21 +136,16 @@ class ProjectRepositoryTest extends TestCase
         ]);
     }
 
-    public function test_it_assign_multiple_frameworks_to_project(): void
+    public function test_it_assign_single_framework_to_project(): void
     {
         $project = Project::factory()->create();
-        $framework1 = Framework::factory()->create();
-        $framework2 = Framework::factory()->create();
+        $framework = Framework::factory()->create();
 
-        $this->projectRepository->addFrameworksToProject($project, [$framework1->id, $framework2->id]);
+        $this->projectRepository->addFrameworkToProject($project, $framework->id);
 
-        $this->assertDatabaseHas('framework_project', [
-            'project_id' => $project->id,
-            'framework_id' => $framework1->id,
-        ]);
-        $this->assertDatabaseHas('framework_project', [
-            'project_id' => $project->id,
-            'framework_id' => $framework2->id,
+        $this->assertDatabaseHas('projects', [
+            'id' => $project->id,
+            'framework_id' => $framework->id,
         ]);
     }
 

--- a/tests/Feature/Repositories/ProjectRepositoryTest.php
+++ b/tests/Feature/Repositories/ProjectRepositoryTest.php
@@ -54,10 +54,11 @@ class ProjectRepositoryTest extends TestCase
 
     public function test_it_get_project_by_id_with_no_framework(): void
     {
-        $project = Project::factory()->create();
+        $project = Project::factory()->create([
+            'framework_id' => null,
+        ]);
         $result = $this->projectRepository->getProjectByID($project);
-        $this->assertEquals(0, $result->total_requirements);
-        $this->assertEquals(0, $result->total_controls);
+        $this->assertEquals(null, $result->framework);
     }
 
     public function test_it_get_project_by_id_with_framework_but_no_requirements_or_controls(): void
@@ -67,8 +68,8 @@ class ProjectRepositoryTest extends TestCase
             'framework_id' => $framework->id,
         ]);
         $result = $this->projectRepository->getProjectByID($project);
-        $this->assertEquals(0, $result->total_requirements);
-        $this->assertEquals(0, $result->total_controls);
+        $this->assertEquals(0, $result->framework->requirements_count);
+        $this->assertEquals(0, $result->framework->controls_count);
     }
 
     public function test_it_get_projects_by_user_id_having_different_roles(): void


### PR DESCRIPTION
This pull request refactors the relationship between projects and frameworks so that each project is now associated with a single framework, rather than supporting multiple frameworks per project. The migration removes the many-to-many pivot table and adds a nullable `framework_id` foreign key to the `projects` table. Controller, repository, resource, and test logic are updated to reflect this change, simplifying the API and data model.