### PR TITLE
Add ProjectMemberResource and update ProjectResource to use it

### DIFF
--- a/app/Http/Resources/ProjectMemberResource.php
+++ b/app/Http/Resources/ProjectMemberResource.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\User
+ */
+class ProjectMemberResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'organization_id' => $this->organization_id,
+            'project_role' => $this->pivot->role ?? null,
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Resources/ProjectMemberResource.php
+++ b/app/Http/Resources/ProjectMemberResource.php
@@ -22,7 +22,7 @@ class ProjectMemberResource extends JsonResource
             'name' => $this->name,
             'email' => $this->email,
             'organization_id' => $this->organization_id,
-            'project_role' => $this->pivot->role ?? null,
+            'project_user_role' => $this->pivot->role ?? null,
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),
         ];

--- a/app/Http/Resources/ProjectResource.php
+++ b/app/Http/Resources/ProjectResource.php
@@ -28,7 +28,7 @@ class ProjectResource extends JsonResource
             'updated_at' => $this->updated_at->toDateTimeString(),
             'total_requirements' => $this->total_requirements,
             'total_controls' => $this->total_controls,
-            'users' => UserResource::collection($this->whenLoaded('users')),
+            'users' => ProjectMemberResource::collection($this->whenLoaded('users')),
             'frameworks' => FrameworkResource::collection($this->whenLoaded('frameworks')),
         ];
     }

--- a/tests/Feature/Controllers/User/ProjectControllerTest.php
+++ b/tests/Feature/Controllers/User/ProjectControllerTest.php
@@ -177,8 +177,8 @@ class ProjectControllerTest extends TestCase
 
         $response = $this->getJson("/api/projects/{$project->id}");
         $response->assertOk();
-        $response->assertJsonPath('data.users.0.project_role', UserProjectRole::OWNER);
-        $response->assertJsonPath('data.users.1.project_role', UserProjectRole::EDITOR);
-        $response->assertJsonPath('data.users.2.project_role', UserProjectRole::REVIEWER);
+        $response->assertJsonPath('data.users.0.project_user_role', UserProjectRole::OWNER);
+        $response->assertJsonPath('data.users.1.project_user_role', UserProjectRole::EDITOR);
+        $response->assertJsonPath('data.users.2.project_user_role', UserProjectRole::REVIEWER);
     }
 }

--- a/tests/Feature/Controllers/User/ProjectControllerTest.php
+++ b/tests/Feature/Controllers/User/ProjectControllerTest.php
@@ -163,4 +163,22 @@ class ProjectControllerTest extends TestCase
         $response = $this->postJson("/api/projects/{$project->id}/add-member", $memberData);
         $response->assertForbidden();
     }
+
+    public function test_it_return_the_user_with__project_user_role(): void
+    {
+        $user1 = User::factory()->create();
+        $user2 = User::factory()->create();
+        $user3 = User::factory()->create();
+        $this->actingAs($user1);
+        $project = Project::factory()->create();
+        $project->users()->attach($user1->id, ['role' => UserProjectRole::OWNER]);
+        $project->users()->attach($user2->id, ['role' => UserProjectRole::EDITOR]);
+        $project->users()->attach($user3->id, ['role' => UserProjectRole::REVIEWER]);
+
+        $response = $this->getJson("/api/projects/{$project->id}");
+        $response->assertOk();
+        $response->assertJsonPath('data.users.0.project_role', UserProjectRole::OWNER);
+        $response->assertJsonPath('data.users.1.project_role', UserProjectRole::EDITOR);
+        $response->assertJsonPath('data.users.2.project_role', UserProjectRole::REVIEWER);
+    }
 }


### PR DESCRIPTION
This pull request introduces a new resource for representing project members, updates the way users are serialized in project responses, and adds test coverage to ensure user roles within a project are correctly exposed. The main changes focus on improving how project members and their roles are returned via the API.