### PR TITLE
feat: Add AI model dataset management functionality

### DIFF
--- a/app/Enums/AiModelDataset/EligibilityStatus.php
+++ b/app/Enums/AiModelDataset/EligibilityStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums\AiModelDataset;
+
+enum EligibilityStatus: string
+{
+    case ELIGIBLE = 'eligible';
+    case ELIGIBLE_WITH_CONDITIONS = 'eligible_with_conditions';
+    case NOT_ELIGIBLE = 'not_eligible';
+}

--- a/app/Enums/AiModelDataset/Role.php
+++ b/app/Enums/AiModelDataset/Role.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums\AiModelDataset;
+
+enum Role: string
+{
+    case PRETRAIN = 'pretrain';
+    case TRAIN = 'train';
+    case FINE_TUNE = 'fine_tune';
+    case ALIGN_RLHF = 'align_rlhf';
+    case VALIDATION = 'validation';
+    case TEST = 'test';
+    case EVAL_BENCHMARK = 'eval_benchmark';
+    case RAG_CORPUS = 'rag_corpus';
+    case DRIFT_BASELINE = 'drift_baseline';
+    case ONLINE_FEEDBACK = 'online_feedback';
+}

--- a/app/Http/Controllers/User/AiModelDatasetController.php
+++ b/app/Http/Controllers/User/AiModelDatasetController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\User;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\AiModelDataset\StoreAiModelDatasetRequest;
+use App\Http\Resources\AiModelDatasetResource;
+use App\Repositories\AiModelRepository;
+use Illuminate\Http\JsonResponse;
+
+class AiModelDatasetController extends Controller
+{
+    public function __construct(private AiModelRepository $aiModelRepository) {}
+
+    /**
+     * Store a newly created AI model dataset link.
+     */
+    public function store(StoreAiModelDatasetRequest $request): JsonResponse
+    {
+        $validated = $request->validated();
+
+        $aiModelDataset = $this->aiModelRepository->assignDataset($validated);
+
+        return response()->json([
+            'error' => false,
+            'message' => 'AI model dataset link created successfully',
+            'data' => new AiModelDatasetResource($aiModelDataset)
+        ], 201);
+    }
+}

--- a/app/Http/Requests/AiModelDataset/StoreAiModelDatasetRequest.php
+++ b/app/Http/Requests/AiModelDataset/StoreAiModelDatasetRequest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Requests\AiModelDataset;
+
+use App\Enums\AiModelDataset\EligibilityStatus;
+use App\Enums\AiModelDataset\Role;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreAiModelDatasetRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'ai_model_id' => ['required', 'integer', 'exists:ai_models,id'],
+            'ai_model_version_id' => ['required', 'integer', 'exists:ai_model_versions,id'],
+            'dataset_id' => ['nullable', 'integer', 'exists:datasets,id'],
+            'dataset_snapshot_id' => [
+                'nullable',
+                'integer',
+                'exists:dataset_snapshots,id',
+                Rule::requiredIf(function () {
+                    $role = $this->input('role');
+                    return in_array($role, [
+                        Role::TRAIN->value,
+                        Role::VALIDATION->value,
+                        Role::TEST->value,
+                        Role::EVAL_BENCHMARK->value
+                    ]);
+                }),
+            ],
+            'role' => ['required', Rule::enum(Role::class)],
+            'access_path' => ['nullable', 'string', 'max:500'],
+            'transform_pack_link' => ['nullable', 'string', 'max:500'],
+            'license_check_ref' => ['nullable', 'string', 'max:255'],
+            'privacy_check_ref' => ['nullable', 'string', 'max:255'],
+            'eligibility_status' => ['nullable', Rule::enum(EligibilityStatus::class)],
+            'notes' => ['nullable', 'string'],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     */
+    public function messages(): array
+    {
+        return [
+            'dataset_snapshot_id.required' => 'A dataset snapshot is required for train, validation, test, and eval_benchmark roles for reproducibility and audit purposes.',
+        ];
+    }
+}

--- a/app/Http/Resources/AiModelDatasetResource.php
+++ b/app/Http/Resources/AiModelDatasetResource.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\AiModelDataset;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin AiModelDataset
+ */
+class AiModelDatasetResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'ai_model_id' => $this->ai_model_id,
+            'ai_model_version_id' => $this->ai_model_version_id,
+            'dataset_id' => $this->dataset_id,
+            'dataset_snapshot_id' => $this->dataset_snapshot_id,
+            'role' => $this->role,
+            'access_path' => $this->access_path,
+            'transform_pack_link' => $this->transform_pack_link,
+            'license_check_ref' => $this->license_check_ref,
+            'privacy_check_ref' => $this->privacy_check_ref,
+            'eligibility_status' => $this->eligibility_status,
+            'notes' => $this->notes,
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+            'ai_model' => new AiModelResource($this->whenLoaded('aiModel')),
+            'ai_model_version' => new AiModelVersionResource($this->whenLoaded('aiModelVersion')),
+            'dataset' => new DatasetResource($this->whenLoaded('dataset')),
+            'dataset_snapshot' => new DatasetSnapshotResource($this->whenLoaded('datasetSnapshot')),
+        ];
+    }
+}

--- a/app/Models/AiModelDataset.php
+++ b/app/Models/AiModelDataset.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AiModelDataset\EligibilityStatus;
+use App\Enums\AiModelDataset\Role;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AiModelDataset extends Model
+{
+    /** @use HasFactory<\Database\Factories\AiModelDatasetFactory> */
+    use HasFactory;
+
+    protected $table = 'ai_model_dataset';
+
+    protected $fillable = [
+        'ai_model_id',
+        'ai_model_version_id',
+        'dataset_id',
+        'dataset_snapshot_id',
+        'role',
+        'access_path',
+        'transform_pack_link',
+        'license_check_ref',
+        'privacy_check_ref',
+        'eligibility_status',
+        'notes',
+    ];
+}

--- a/app/Repositories/AiModelRepository.php
+++ b/app/Repositories/AiModelRepository.php
@@ -3,6 +3,7 @@
 namespace App\Repositories;
 
 use App\Models\AiModel;
+use App\Models\AiModelDataset;
 use Illuminate\Database\Eloquent\Collection;
 
 class AiModelRepository
@@ -28,5 +29,18 @@ class AiModelRepository
     {
         $data = AiModel::with(['createdBy', 'updatedBy'])->where('id', $id)->first();
         return $data;
+    }
+
+    /**
+     * Assign a dataset link to an AI model.
+     * Gate: Rejects links for train/validation/test/eval_benchmark roles without snapshot_id.
+     *
+     * @param array $data
+     * @return \App\Models\AiModelDataset
+     * @throws \InvalidArgumentException
+     */
+    public function assignDataset(array $data): AiModelDataset
+    {
+        return AiModelDataset::create($data);
     }
 }

--- a/database/factories/AiModelDatasetFactory.php
+++ b/database/factories/AiModelDatasetFactory.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\AiModelDataset\EligibilityStatus;
+use App\Enums\AiModelDataset\Role;
+use App\Models\AiModel;
+use App\Models\AiModelDataset;
+use App\Models\AiModelVersion;
+use App\Models\Dataset;
+use App\Models\DatasetSnapshot;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\AiModelDataset>
+ */
+class AiModelDatasetFactory extends Factory
+{
+    protected $model = AiModelDataset::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $role = fake()->randomElement(Role::cases());
+
+        // Roles that require snapshot_id: train, validation, test, eval_benchmark
+        $requiresSnapshot = in_array($role, [
+            Role::TRAIN,
+            Role::VALIDATION,
+            Role::TEST,
+            Role::EVAL_BENCHMARK,
+        ]);
+
+        return [
+            'ai_model_id' => AiModel::factory(),
+            'ai_model_version_id' => AiModelVersion::factory(),
+            'dataset_id' => fake()->optional(0.7)->passthrough(Dataset::factory()),
+            'dataset_snapshot_id' => $requiresSnapshot
+                ? DatasetSnapshot::factory()
+                : fake()->optional(0.3)->passthrough(DatasetSnapshot::factory()),
+            'role' => $role->value,
+            'access_path' => fake()->optional()->filePath(),
+            'transform_pack_link' => fake()->optional()->url(),
+            'license_check_ref' => fake()->optional()->regexify('LIC-[0-9]{6}'),
+            'privacy_check_ref' => fake()->optional()->regexify('PRI-[0-9]{6}'),
+            'eligibility_status' => fake()->optional()->randomElement(EligibilityStatus::cases())?->value,
+            'notes' => fake()->optional()->sentence(15),
+        ];
+    }
+
+    /**
+     * State for pretrain role.
+     */
+    public function pretrain(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'role' => Role::PRETRAIN->value,
+            'dataset_snapshot_id' => fake()->optional(0.3)->passthrough(DatasetSnapshot::factory()),
+        ]);
+    }
+
+    /**
+     * State for train role (requires snapshot).
+     */
+    public function train(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'role' => Role::TRAIN->value,
+            'dataset_snapshot_id' => DatasetSnapshot::factory(),
+        ]);
+    }
+
+    /**
+     * State for fine_tune role.
+     */
+    public function fineTune(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'role' => Role::FINE_TUNE->value,
+            'dataset_snapshot_id' => fake()->optional(0.3)->passthrough(DatasetSnapshot::factory()),
+        ]);
+    }
+
+    /**
+     * State for align_rlhf role.
+     */
+    public function alignRlhf(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'role' => Role::ALIGN_RLHF->value,
+            'dataset_snapshot_id' => fake()->optional(0.3)->passthrough(DatasetSnapshot::factory()),
+        ]);
+    }
+
+    /**
+     * State for validation role (requires snapshot).
+     */
+    public function validation(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'role' => Role::VALIDATION->value,
+            'dataset_snapshot_id' => DatasetSnapshot::factory(),
+        ]);
+    }
+
+    /**
+     * State for test role (requires snapshot).
+     */
+    public function test(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'role' => Role::TEST->value,
+            'dataset_snapshot_id' => DatasetSnapshot::factory(),
+        ]);
+    }
+
+    /**
+     * State for eval_benchmark role (requires snapshot).
+     */
+    public function evalBenchmark(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'role' => Role::EVAL_BENCHMARK->value,
+            'dataset_snapshot_id' => DatasetSnapshot::factory(),
+        ]);
+    }
+
+    /**
+     * State for rag_corpus role.
+     */
+    public function ragCorpus(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'role' => Role::RAG_CORPUS->value,
+            'dataset_snapshot_id' => fake()->optional(0.3)->passthrough(DatasetSnapshot::factory()),
+        ]);
+    }
+
+    /**
+     * State for drift_baseline role.
+     */
+    public function driftBaseline(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'role' => Role::DRIFT_BASELINE->value,
+            'dataset_snapshot_id' => fake()->optional(0.3)->passthrough(DatasetSnapshot::factory()),
+        ]);
+    }
+
+    /**
+     * State for online_feedback role.
+     */
+    public function onlineFeedback(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'role' => Role::ONLINE_FEEDBACK->value,
+            'dataset_snapshot_id' => fake()->optional(0.3)->passthrough(DatasetSnapshot::factory()),
+        ]);
+    }
+
+    /**
+     * State for eligible status.
+     */
+    public function eligible(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'eligibility_status' => EligibilityStatus::ELIGIBLE->value,
+        ]);
+    }
+
+    /**
+     * State for eligible with conditions status.
+     */
+    public function eligibleWithConditions(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'eligibility_status' => EligibilityStatus::ELIGIBLE_WITH_CONDITIONS->value,
+            'notes' => fake()->sentence(20),
+        ]);
+    }
+
+    /**
+     * State for not eligible status.
+     */
+    public function notEligible(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'eligibility_status' => EligibilityStatus::NOT_ELIGIBLE->value,
+            'notes' => fake()->sentence(20),
+        ]);
+    }
+
+    /**
+     * State with all optional fields filled.
+     */
+    public function complete(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'dataset_id' => Dataset::factory(),
+            'dataset_snapshot_id' => DatasetSnapshot::factory(),
+            'access_path' => fake()->filePath(),
+            'transform_pack_link' => fake()->url(),
+            'license_check_ref' => fake()->regexify('LIC-[0-9]{6}'),
+            'privacy_check_ref' => fake()->regexify('PRI-[0-9]{6}'),
+            'eligibility_status' => fake()->randomElement(EligibilityStatus::cases())->value,
+            'notes' => fake()->sentence(15),
+        ]);
+    }
+
+    /**
+     * State without snapshot (for roles that don't require it).
+     */
+    public function withoutSnapshot(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'dataset_snapshot_id' => null,
+            'role' => fake()->randomElement([
+                Role::PRETRAIN,
+                Role::FINE_TUNE,
+                Role::ALIGN_RLHF,
+                Role::RAG_CORPUS,
+                Role::DRIFT_BASELINE,
+                Role::ONLINE_FEEDBACK,
+            ])->value,
+        ]);
+    }
+}

--- a/database/migrations/2025_10_24_093347_create_ai_model_dataset.php
+++ b/database/migrations/2025_10_24_093347_create_ai_model_dataset.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Models\AiModel;
+use App\Models\AiModelVersion;
+use App\Models\Dataset;
+use App\Models\DatasetSnapshot;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ai_model_dataset', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(AiModel::class)->constrained('ai_models')->onDelete('cascade');
+            $table->foreignIdFor(AiModelVersion::class)->constrained('ai_model_versions')->onDelete('cascade');
+            $table->foreignIdFor(Dataset::class)->nullable()->constrained('datasets')->onDelete('cascade');
+            $table->foreignIdFor(DatasetSnapshot::class)->nullable()->constrained('dataset_snapshots')->onDelete('cascade');
+            $table->string('role');
+            $table->string('access_path')->nullable();
+            $table->string('transform_pack_link')->nullable();
+            $table->string('license_check_ref')->nullable();
+            $table->string('privacy_check_ref')->nullable();
+            $table->string('eligibility_status')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('table_ai_model_dataset');
+    }
+};

--- a/routes/api/user.php
+++ b/routes/api/user.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\User\DatasetController;
 use App\Http\Controllers\User\DataElementController;
 use App\Http\Controllers\User\DatasetElementController;
 use App\Http\Controllers\User\DatasetSnapshotController;
+use App\Http\Controllers\User\AiModelDatasetController;
 
 Route::middleware(['auth:supabase'])->group(function () {
     Route::prefix('/plans')->controller(BillingController::class)->group(function () {
@@ -137,5 +138,9 @@ Route::middleware(['auth:supabase'])->group(function () {
         Route::get('{datasetSnapshot}', 'show');
         Route::post('{datasetSnapshot}', 'update');
         Route::delete('{datasetSnapshot}', 'destroy');
+    });
+
+    Route::prefix('ai-model-datasets')->controller(AiModelDatasetController::class)->group(function () {
+        Route::post('', 'store');
     });
 });

--- a/tests/Feature/Controllers/User/AiModelDatasetControllerTest.php
+++ b/tests/Feature/Controllers/User/AiModelDatasetControllerTest.php
@@ -1,0 +1,508 @@
+<?php
+
+namespace Tests\Feature\Controllers\User;
+
+use App\Enums\AiModelDataset\EligibilityStatus;
+use App\Enums\AiModelDataset\Role;
+use App\Models\AiModel;
+use App\Models\AiModelVersion;
+use App\Models\Dataset;
+use App\Models\DatasetSnapshot;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AiModelDatasetControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    private function validPayload(array $overrides = []): array
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $dataset = Dataset::factory()->create();
+        $snapshot = DatasetSnapshot::factory()->create(['dataset_id' => $dataset->id]);
+
+        return array_merge([
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'dataset_id' => $dataset->id,
+            'dataset_snapshot_id' => $snapshot->id,
+            'role' => Role::TRAIN->value,
+            'access_path' => '/data/training/path',
+            'transform_pack_link' => 'https://transforms.example.com/pack123',
+            'license_check_ref' => 'LIC-123456',
+            'privacy_check_ref' => 'PRI-789012',
+            'eligibility_status' => EligibilityStatus::ELIGIBLE->value,
+            'notes' => 'Test dataset assignment',
+        ], $overrides);
+    }
+
+    /**
+     * Test user can create AI model dataset link with all fields.
+     */
+    public function test_user_can_create_ai_model_dataset_link_with_all_fields(): void
+    {
+        $payload = $this->validPayload();
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'error',
+                'message',
+                'data' => [
+                    'id',
+                    'ai_model_id',
+                    'ai_model_version_id',
+                    'dataset_id',
+                    'dataset_snapshot_id',
+                    'role',
+                    'access_path',
+                    'transform_pack_link',
+                    'license_check_ref',
+                    'privacy_check_ref',
+                    'eligibility_status',
+                    'notes',
+                    'created_at',
+                    'updated_at',
+                ]
+            ])
+            ->assertJson([
+                'error' => false,
+                'message' => 'AI model dataset link created successfully',
+            ]);
+
+        $this->assertDatabaseHas('ai_model_dataset', [
+            'ai_model_id' => $payload['ai_model_id'],
+            'ai_model_version_id' => $payload['ai_model_version_id'],
+            'role' => $payload['role'],
+        ]);
+    }
+
+    /**
+     * Test user can create link with minimal required fields (pretrain role).
+     */
+    public function test_user_can_create_link_with_minimal_fields(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+
+        $payload = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'role' => Role::PRETRAIN->value,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'error' => false,
+                'message' => 'AI model dataset link created successfully',
+            ]);
+    }
+
+    /**
+     * Test ai_model_id is required.
+     */
+    public function test_ai_model_id_is_required(): void
+    {
+        $payload = $this->validPayload(['ai_model_id' => null]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['ai_model_id']);
+    }
+
+    /**
+     * Test ai_model_id must exist in ai_models table.
+     */
+    public function test_ai_model_id_must_exist(): void
+    {
+        $payload = $this->validPayload(['ai_model_id' => 999999]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['ai_model_id']);
+    }
+
+    /**
+     * Test ai_model_version_id is required.
+     */
+    public function test_ai_model_version_id_is_required(): void
+    {
+        $payload = $this->validPayload(['ai_model_version_id' => null]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['ai_model_version_id']);
+    }
+
+    /**
+     * Test ai_model_version_id must exist in ai_model_versions table.
+     */
+    public function test_ai_model_version_id_must_exist(): void
+    {
+        $payload = $this->validPayload(['ai_model_version_id' => 999999]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['ai_model_version_id']);
+    }
+
+    /**
+     * Test dataset_id must exist if provided.
+     */
+    public function test_dataset_id_must_exist_if_provided(): void
+    {
+        $payload = $this->validPayload(['dataset_id' => 999999]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['dataset_id']);
+    }
+
+    /**
+     * Test dataset_snapshot_id must exist if provided.
+     */
+    public function test_dataset_snapshot_id_must_exist_if_provided(): void
+    {
+        $payload = $this->validPayload(['dataset_snapshot_id' => 999999]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['dataset_snapshot_id']);
+    }
+
+    /**
+     * Test role is required.
+     */
+    public function test_role_is_required(): void
+    {
+        $payload = $this->validPayload(['role' => null]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['role']);
+    }
+
+    /**
+     * Test role must be valid enum value.
+     */
+    public function test_role_must_be_valid_enum(): void
+    {
+        $payload = $this->validPayload(['role' => 'invalid_role']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['role']);
+    }
+
+    /**
+     * Test all role enum values are accepted.
+     */
+    public function test_all_role_enum_values_are_accepted(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $snapshot = DatasetSnapshot::factory()->create();
+
+        foreach (Role::cases() as $role) {
+            $payload = [
+                'ai_model_id' => $aiModel->id,
+                'ai_model_version_id' => $aiModelVersion->id,
+                'role' => $role->value,
+            ];
+
+            // Add snapshot for roles that require it
+            if (in_array($role, [Role::TRAIN, Role::VALIDATION, Role::TEST, Role::EVAL_BENCHMARK])) {
+                $payload['dataset_snapshot_id'] = $snapshot->id;
+            }
+
+            $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+            $response->assertStatus(201);
+        }
+    }
+
+    /**
+     * Test dataset_snapshot_id is required for train role.
+     */
+    public function test_dataset_snapshot_id_is_required_for_train_role(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+
+        $payload = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'role' => Role::TRAIN->value,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['dataset_snapshot_id']);
+    }
+
+    /**
+     * Test dataset_snapshot_id is required for validation role.
+     */
+    public function test_dataset_snapshot_id_is_required_for_validation_role(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+
+        $payload = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'role' => Role::VALIDATION->value,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['dataset_snapshot_id']);
+    }
+
+    /**
+     * Test dataset_snapshot_id is required for test role.
+     */
+    public function test_dataset_snapshot_id_is_required_for_test_role(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+
+        $payload = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'role' => Role::TEST->value,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['dataset_snapshot_id']);
+    }
+
+    /**
+     * Test dataset_snapshot_id is required for eval_benchmark role.
+     */
+    public function test_dataset_snapshot_id_is_required_for_eval_benchmark_role(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+
+        $payload = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'role' => Role::EVAL_BENCHMARK->value,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['dataset_snapshot_id']);
+    }
+
+    /**
+     * Test dataset_snapshot_id is optional for pretrain role.
+     */
+    public function test_dataset_snapshot_id_is_optional_for_pretrain_role(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+
+        $payload = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'role' => Role::PRETRAIN->value,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(201);
+    }
+
+    /**
+     * Test dataset_snapshot_id is optional for fine_tune role.
+     */
+    public function test_dataset_snapshot_id_is_optional_for_fine_tune_role(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+
+        $payload = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'role' => Role::FINE_TUNE->value,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(201);
+    }
+
+    /**
+     * Test eligibility_status must be valid enum if provided.
+     */
+    public function test_eligibility_status_must_be_valid_enum(): void
+    {
+        $payload = $this->validPayload(['eligibility_status' => 'invalid_status']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['eligibility_status']);
+    }
+
+    /**
+     * Test all eligibility status enum values are accepted.
+     */
+    public function test_all_eligibility_status_enum_values_are_accepted(): void
+    {
+        foreach (EligibilityStatus::cases() as $status) {
+            $payload = $this->validPayload(['eligibility_status' => $status->value]);
+
+            $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+            $response->assertStatus(201);
+        }
+    }
+
+    /**
+     * Test access_path max length is 500.
+     */
+    public function test_access_path_max_length_is_500(): void
+    {
+        $payload = $this->validPayload(['access_path' => str_repeat('a', 501)]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['access_path']);
+    }
+
+    /**
+     * Test transform_pack_link max length is 500.
+     */
+    public function test_transform_pack_link_max_length_is_500(): void
+    {
+        $payload = $this->validPayload(['transform_pack_link' => str_repeat('a', 501)]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['transform_pack_link']);
+    }
+
+    /**
+     * Test license_check_ref max length is 255.
+     */
+    public function test_license_check_ref_max_length_is_255(): void
+    {
+        $payload = $this->validPayload(['license_check_ref' => str_repeat('a', 256)]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['license_check_ref']);
+    }
+
+    /**
+     * Test privacy_check_ref max length is 255.
+     */
+    public function test_privacy_check_ref_max_length_is_255(): void
+    {
+        $payload = $this->validPayload(['privacy_check_ref' => str_repeat('a', 256)]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['privacy_check_ref']);
+    }
+
+    /**
+     * Test unauthenticated user cannot create dataset link.
+     */
+    public function test_unauthenticated_user_cannot_create_dataset_link(): void
+    {
+        $payload = $this->validPayload();
+
+        $response = $this->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * Test nullable fields can be omitted.
+     */
+    public function test_nullable_fields_can_be_omitted(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $snapshot = DatasetSnapshot::factory()->create();
+
+        $payload = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'dataset_snapshot_id' => $snapshot->id,
+            'role' => Role::TRAIN->value,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(201);
+    }
+
+    /**
+     * Test link with eligible_with_conditions status.
+     */
+    public function test_link_with_eligible_with_conditions_status(): void
+    {
+        $payload = $this->validPayload([
+            'eligibility_status' => EligibilityStatus::ELIGIBLE_WITH_CONDITIONS->value,
+            'notes' => 'Requires additional privacy review.',
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.eligibility_status', EligibilityStatus::ELIGIBLE_WITH_CONDITIONS->value)
+            ->assertJsonPath('data.notes', 'Requires additional privacy review.');
+    }
+
+    /**
+     * Test link with not_eligible status.
+     */
+    public function test_link_with_not_eligible_status(): void
+    {
+        $payload = $this->validPayload([
+            'eligibility_status' => EligibilityStatus::NOT_ELIGIBLE->value,
+            'notes' => 'License restrictions prevent usage.',
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-model-datasets', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.eligibility_status', EligibilityStatus::NOT_ELIGIBLE->value)
+            ->assertJsonPath('data.notes', 'License restrictions prevent usage.');
+    }
+}

--- a/tests/Feature/Repositories/AiModelRepositoryTest.php
+++ b/tests/Feature/Repositories/AiModelRepositoryTest.php
@@ -2,7 +2,13 @@
 
 namespace Tests\Feature\Repositories;
 
+use App\Enums\AiModelDataset\EligibilityStatus;
+use App\Enums\AiModelDataset\Role;
 use App\Models\AiModel;
+use App\Models\AiModelDataset;
+use App\Models\AiModelVersion;
+use App\Models\Dataset;
+use App\Models\DatasetSnapshot;
 use App\Models\User;
 use App\Models\Organization;
 use App\Repositories\AiModelRepository;
@@ -15,6 +21,7 @@ use App\Enums\StrategicImportance;
 use App\Enums\OrganizationalRole;
 use App\Enums\OwnershipType;
 use App\Enums\PrimaryCategory;
+
 use Illuminate\Foundation\Testing\WithFaker;
 
 class AiModelRepositoryTest extends TestCase
@@ -100,5 +107,258 @@ class AiModelRepositoryTest extends TestCase
             'id' => $aiModel->id,
             'name' => $aiModel->name,
         ]);
+    }
+
+    /**
+     * Test assign dataset with pretrain role (no snapshot required).
+     */
+    public function test_assign_dataset_with_pretrain_role_without_snapshot(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'dataset_id' => $dataset->id,
+            'role' => Role::PRETRAIN->value,
+        ];
+
+        $result = $this->aiModelRepository->assignDataset($data);
+
+        $this->assertInstanceOf(AiModelDataset::class, $result);
+        $this->assertEquals($aiModel->id, $result->ai_model_id);
+        $this->assertEquals(Role::PRETRAIN->value, $result->role);
+        $this->assertNull($result->dataset_snapshot_id);
+        $this->assertDatabaseHas('ai_model_dataset', [
+            'ai_model_id' => $aiModel->id,
+            'role' => Role::PRETRAIN->value,
+        ]);
+    }
+
+    /**
+     * Test assign dataset with train role and snapshot.
+     */
+    public function test_assign_dataset_with_train_role_and_snapshot(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $dataset = Dataset::factory()->create();
+        $snapshot = DatasetSnapshot::factory()->create(['dataset_id' => $dataset->id]);
+
+        $data = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'dataset_id' => $dataset->id,
+            'dataset_snapshot_id' => $snapshot->id,
+            'role' => Role::TRAIN->value,
+        ];
+
+        $result = $this->aiModelRepository->assignDataset($data);
+
+        $this->assertInstanceOf(AiModelDataset::class, $result);
+        $this->assertEquals($snapshot->id, $result->dataset_snapshot_id);
+        $this->assertEquals(Role::TRAIN->value, $result->role);
+        $this->assertDatabaseHas('ai_model_dataset', [
+            'ai_model_id' => $aiModel->id,
+            'dataset_snapshot_id' => $snapshot->id,
+            'role' => Role::TRAIN->value,
+        ]);
+    }
+
+    /**
+     * Test assign dataset with validation role and snapshot.
+     */
+    public function test_assign_dataset_with_validation_role_and_snapshot(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $snapshot = DatasetSnapshot::factory()->create();
+
+        $data = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'dataset_snapshot_id' => $snapshot->id,
+            'role' => Role::VALIDATION->value,
+        ];
+
+        $result = $this->aiModelRepository->assignDataset($data);
+
+        $this->assertInstanceOf(AiModelDataset::class, $result);
+        $this->assertEquals(Role::VALIDATION->value, $result->role);
+        $this->assertEquals($snapshot->id, $result->dataset_snapshot_id);
+    }
+
+    /**
+     * Test assign dataset with test role and snapshot.
+     */
+    public function test_assign_dataset_with_test_role_and_snapshot(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $snapshot = DatasetSnapshot::factory()->create();
+
+        $data = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'dataset_snapshot_id' => $snapshot->id,
+            'role' => Role::TEST->value,
+        ];
+
+        $result = $this->aiModelRepository->assignDataset($data);
+
+        $this->assertInstanceOf(AiModelDataset::class, $result);
+        $this->assertEquals(Role::TEST->value, $result->role);
+    }
+
+    /**
+     * Test assign dataset with eval_benchmark role and snapshot.
+     */
+    public function test_assign_dataset_with_eval_benchmark_role_and_snapshot(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $snapshot = DatasetSnapshot::factory()->create();
+
+        $data = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'dataset_snapshot_id' => $snapshot->id,
+            'role' => Role::EVAL_BENCHMARK->value,
+        ];
+
+        $result = $this->aiModelRepository->assignDataset($data);
+
+        $this->assertInstanceOf(AiModelDataset::class, $result);
+        $this->assertEquals(Role::EVAL_BENCHMARK->value, $result->role);
+    }
+
+    /**
+     * Test assign dataset with all optional fields.
+     */
+    public function test_assign_dataset_with_all_optional_fields(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $dataset = Dataset::factory()->create();
+        $snapshot = DatasetSnapshot::factory()->create(['dataset_id' => $dataset->id]);
+
+        $data = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'dataset_id' => $dataset->id,
+            'dataset_snapshot_id' => $snapshot->id,
+            'role' => Role::TRAIN->value,
+            'access_path' => '/data/training/path',
+            'transform_pack_link' => 'https://transforms.example.com/pack123',
+            'license_check_ref' => 'LIC-123456',
+            'privacy_check_ref' => 'PRI-789012',
+            'eligibility_status' => EligibilityStatus::ELIGIBLE->value,
+            'notes' => 'This is a test note for the dataset assignment.',
+        ];
+
+        $result = $this->aiModelRepository->assignDataset($data);
+
+        $this->assertInstanceOf(AiModelDataset::class, $result);
+        $this->assertEquals('/data/training/path', $result->access_path);
+        $this->assertEquals('https://transforms.example.com/pack123', $result->transform_pack_link);
+        $this->assertEquals('LIC-123456', $result->license_check_ref);
+        $this->assertEquals('PRI-789012', $result->privacy_check_ref);
+        $this->assertEquals(EligibilityStatus::ELIGIBLE->value, $result->eligibility_status);
+        $this->assertEquals('This is a test note for the dataset assignment.', $result->notes);
+    }
+
+    /**
+     * Test assign dataset with fine_tune role (no snapshot required).
+     */
+    public function test_assign_dataset_with_fine_tune_role_without_snapshot(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'dataset_id' => $dataset->id,
+            'role' => Role::FINE_TUNE->value,
+        ];
+
+        $result = $this->aiModelRepository->assignDataset($data);
+
+        $this->assertInstanceOf(AiModelDataset::class, $result);
+        $this->assertEquals(Role::FINE_TUNE->value, $result->role);
+        $this->assertNull($result->dataset_snapshot_id);
+    }
+
+    /**
+     * Test assign dataset with rag_corpus role (no snapshot required).
+     */
+    public function test_assign_dataset_with_rag_corpus_role_without_snapshot(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'dataset_id' => $dataset->id,
+            'role' => Role::RAG_CORPUS->value,
+        ];
+
+        $result = $this->aiModelRepository->assignDataset($data);
+
+        $this->assertInstanceOf(AiModelDataset::class, $result);
+        $this->assertEquals(Role::RAG_CORPUS->value, $result->role);
+    }
+
+    /**
+     * Test assign dataset with eligibility status eligible_with_conditions.
+     */
+    public function test_assign_dataset_with_eligibility_status_eligible_with_conditions(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'dataset_id' => $dataset->id,
+            'role' => Role::PRETRAIN->value,
+            'eligibility_status' => EligibilityStatus::ELIGIBLE_WITH_CONDITIONS->value,
+            'notes' => 'Requires additional privacy review.',
+        ];
+
+        $result = $this->aiModelRepository->assignDataset($data);
+
+        $this->assertEquals(EligibilityStatus::ELIGIBLE_WITH_CONDITIONS->value, $result->eligibility_status);
+        $this->assertEquals('Requires additional privacy review.', $result->notes);
+    }
+
+    /**
+     * Test assign dataset with eligibility status not_eligible.
+     */
+    public function test_assign_dataset_with_eligibility_status_not_eligible(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'dataset_id' => $dataset->id,
+            'role' => Role::PRETRAIN->value,
+            'eligibility_status' => EligibilityStatus::NOT_ELIGIBLE->value,
+            'notes' => 'License restrictions prevent usage.',
+        ];
+
+        $result = $this->aiModelRepository->assignDataset($data);
+
+        $this->assertEquals(EligibilityStatus::NOT_ELIGIBLE->value, $result->eligibility_status);
+        $this->assertEquals('License restrictions prevent usage.', $result->notes);
     }
 }


### PR DESCRIPTION
- Implemented AiModelDatasetController for handling dataset assignments to AI models.
- Created StoreAiModelDatasetRequest for validating incoming requests.
- Added AiModelDataset model and corresponding database migration.
- Introduced enums for Role and EligibilityStatus to manage dataset roles and eligibility.
- Developed AiModelDatasetResource for API responses.
- Created comprehensive tests for the AiModelDatasetController, covering various scenarios and validations.
- Updated routes to include new AI model dataset endpoints.