### PR TITLE
feat: Add Consent Coverage management functionality

### DIFF
--- a/app/Http/Controllers/User/ConsentCoverageController.php
+++ b/app/Http/Controllers/User/ConsentCoverageController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\User;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\ConsentCoverage\ListConsentCoverageRequest;
+use App\Http\Requests\ConsentCoverage\StoreConsentCoverageRequest;
+use App\Http\Requests\ConsentCoverage\UpdateConsentCoverageRequest;
+use App\Http\Resources\ConsentCoverageResource;
+use App\Models\ConsentCoverage;
+use App\Repositories\ConsentCoverageRepository;
+use Illuminate\Http\JsonResponse;
+
+class ConsentCoverageController extends Controller
+{
+    public function __construct(private ConsentCoverageRepository $consentCoverageRepository) {}
+
+    /**
+     * Display a listing of consent coverages.
+     */
+    public function index(ListConsentCoverageRequest $request): JsonResponse
+    {
+        $perPage = $request->input('per_page', 15);
+        $coverages = $this->consentCoverageRepository->getPaginatedCoverages($perPage);
+
+        return response()->json([
+            'error' => false,
+            'data' => $coverages,
+            'message' => 'Consent coverages retrieved successfully'
+        ]);
+    }
+
+    /**
+     * Store a newly created consent coverage.
+     */
+    public function store(StoreConsentCoverageRequest $request): JsonResponse
+    {
+        $validated = $request->validated();
+
+        $coverage = $this->consentCoverageRepository->createCoverage($validated);
+
+        return response()->json([
+            'error' => false,
+            'message' => 'Consent coverage created successfully',
+            'data' => new ConsentCoverageResource($coverage)
+        ], 201);
+    }
+
+    /**
+     * Display the specified consent coverage.
+     */
+    public function show(ConsentCoverage $consentCoverage): JsonResponse
+    {
+        return response()->json([
+            'error' => false,
+            'data' => new ConsentCoverageResource($consentCoverage),
+            'message' => 'Consent coverage retrieved successfully'
+        ]);
+    }
+
+    /**
+     * Update the specified consent coverage.
+     */
+    public function update(UpdateConsentCoverageRequest $request, ConsentCoverage $consentCoverage): JsonResponse
+    {
+        $validated = $request->validated();
+
+        $this->consentCoverageRepository->updateCoverage($consentCoverage, $validated);
+
+        return response()->json([
+            'error' => false,
+            'message' => 'Consent coverage updated successfully',
+            'data' => new ConsentCoverageResource($consentCoverage->fresh())
+        ], 200);
+    }
+
+    /**
+     * Remove the specified consent coverage.
+     */
+    public function destroy(ConsentCoverage $consentCoverage): JsonResponse
+    {
+        $this->consentCoverageRepository->deleteCoverage($consentCoverage);
+
+        return response()->json([
+            'error' => false,
+            'message' => 'Consent coverage deleted successfully',
+            'data' => null,
+        ]);
+    }
+}

--- a/app/Http/Requests/ConsentCoverage/ListConsentCoverageRequest.php
+++ b/app/Http/Requests/ConsentCoverage/ListConsentCoverageRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\ConsentCoverage;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ListConsentCoverageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/ConsentCoverage/StoreConsentCoverageRequest.php
+++ b/app/Http/Requests/ConsentCoverage/StoreConsentCoverageRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\ConsentCoverage;
+
+use App\Enums\UserConsent\ConsentPurpose;
+use App\Enums\UserConsent\Jurisdiction;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreConsentCoverageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'dataset_id' => ['required', 'integer', 'exists:datasets,id'],
+            'snapshot_id' => ['nullable', 'integer', 'exists:dataset_snapshots,id'],
+            'purpose' => ['required', Rule::enum(ConsentPurpose::class)],
+            'jurisdiction' => ['required', Rule::enum(Jurisdiction::class)],
+            'as_of' => ['required', 'date'],
+            'subjects_total' => ['required', 'integer', 'min:0'],
+            'subjects_with_valid_consent' => ['required', 'integer', 'min:0', 'lte:subjects_total'],
+            'coverage_pct' => ['required', 'numeric', 'min:0', 'max:100'],
+            'evidence_ref' => ['required', 'string', 'max:255'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'subjects_with_valid_consent.lte' => 'Subjects with valid consent cannot exceed total subjects.',
+        ];
+    }
+}

--- a/app/Http/Requests/ConsentCoverage/UpdateConsentCoverageRequest.php
+++ b/app/Http/Requests/ConsentCoverage/UpdateConsentCoverageRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\ConsentCoverage;
+
+use App\Enums\UserConsent\ConsentPurpose;
+use App\Enums\UserConsent\Jurisdiction;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateConsentCoverageRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'dataset_id' => ['sometimes', 'integer', 'exists:datasets,id'],
+            'snapshot_id' => ['nullable', 'integer', 'exists:dataset_snapshots,id'],
+            'purpose' => ['sometimes', Rule::enum(ConsentPurpose::class)],
+            'jurisdiction' => ['sometimes', Rule::enum(Jurisdiction::class)],
+            'as_of' => ['sometimes', 'date'],
+            'subjects_total' => ['sometimes', 'integer', 'min:0'],
+            'subjects_with_valid_consent' => ['sometimes', 'integer', 'min:0', 'lte:subjects_total'],
+            'coverage_pct' => ['sometimes', 'numeric', 'min:0', 'max:100'],
+            'evidence_ref' => ['sometimes', 'string', 'max:255'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'subjects_with_valid_consent.lte' => 'Subjects with valid consent cannot exceed total subjects.',
+        ];
+    }
+}

--- a/app/Http/Resources/ConsentCoverageResource.php
+++ b/app/Http/Resources/ConsentCoverageResource.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Carbon;
+
+/**
+ * @mixin \App\Models\ConsentCoverage
+ */
+class ConsentCoverageResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'dataset_id' => $this->dataset_id,
+            'snapshot_id' => $this->snapshot_id,
+            'purpose' => $this->purpose,
+            'jurisdiction' => $this->jurisdiction,
+            'as_of' => $this->as_of ? Carbon::parse($this->as_of)->toDateTimeString() : null,
+            'subjects_total' => $this->subjects_total,
+            'subjects_with_valid_consent' => $this->subjects_with_valid_consent,
+            'coverage_pct' => (float) $this->coverage_pct,
+            'evidence_ref' => $this->evidence_ref,
+            'created_at' => $this->created_at->toDateTimeString(),
+            'updated_at' => $this->updated_at->toDateTimeString(),
+            'dataset' => new DatasetResource($this->whenLoaded('dataset')),
+            'snapshot' => new DatasetSnapshotResource($this->whenLoaded('snapshot')),
+        ];
+    }
+}

--- a/app/Models/ConsentCoverage.php
+++ b/app/Models/ConsentCoverage.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ConsentCoverage extends Model
+{
+    /** @use HasFactory<\Database\Factories\ConsentCoverageFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'dataset_id',
+        'snapshot_id',
+        'purpose',
+        'jurisdiction',
+        'as_of',
+        'subjects_total',
+        'subjects_with_valid_consent',
+        'coverage_pct',
+        'evidence_ref'
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'as_of' => 'datetime',
+            'subjects_total' => 'integer',
+            'subjects_with_valid_consent' => 'integer',
+            'coverage_pct' => 'decimal:2',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Dataset, $this>
+     */
+    public function dataset(): BelongsTo
+    {
+        return $this->belongsTo(Dataset::class);
+    }
+
+    /**
+     * @return BelongsTo<DatasetSnapshot, $this>
+     */
+    public function snapshot(): BelongsTo
+    {
+        return $this->belongsTo(DatasetSnapshot::class, 'snapshot_id');
+    }
+}

--- a/app/Repositories/ConsentCoverageRepository.php
+++ b/app/Repositories/ConsentCoverageRepository.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Enums\UserConsent\ConsentPurpose;
+use App\Enums\UserConsent\Jurisdiction;
+use App\Models\ConsentCoverage;
+use App\Models\Dataset;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Collection;
+
+class ConsentCoverageRepository
+{
+    /**
+     * Get paginated consent coverages.
+     *
+     * @param int $perPage
+     * @return LengthAwarePaginator<int, ConsentCoverage>
+     */
+    public function getPaginatedCoverages(int $perPage = 15): LengthAwarePaginator
+    {
+        return ConsentCoverage::with(['dataset', 'snapshot'])
+            ->orderBy('as_of', 'desc')
+            ->paginate($perPage);
+    }
+
+    /**
+     * Create a new consent coverage.
+     *
+     * @param array $data
+     * @return ConsentCoverage
+     */
+    public function createCoverage(array $data): ConsentCoverage
+    {
+        if (!isset($data['created_at'])) {
+            $data['created_at'] = now();
+        }
+
+        return ConsentCoverage::create($data);
+    }
+
+    /**
+     * Update a consent coverage.
+     *
+     * @param ConsentCoverage $coverage
+     * @param array $data
+     * @return bool
+     */
+    public function updateCoverage(ConsentCoverage $coverage, array $data): bool
+    {
+        return $coverage->update($data);
+    }
+
+    /**
+     * Delete a consent coverage.
+     *
+     * @param ConsentCoverage $coverage
+     * @return bool
+     */
+    public function deleteCoverage(ConsentCoverage $coverage): bool
+    {
+        return $coverage->delete() ?? false;
+    }
+}

--- a/database/factories/ConsentCoverageFactory.php
+++ b/database/factories/ConsentCoverageFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\UserConsent\ConsentPurpose;
+use App\Enums\UserConsent\Jurisdiction;
+use App\Models\Dataset;
+use App\Models\DatasetSnapshot;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ConsentCoverage>
+ */
+class ConsentCoverageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $subjectsTotal = fake()->numberBetween(1000, 100000);
+        $subjectsWithConsent = fake()->numberBetween(0, $subjectsTotal);
+        $coveragePct = $subjectsTotal > 0
+            ? round(($subjectsWithConsent / $subjectsTotal) * 100, 2)
+            : 0.00;
+
+        $asOf = fake()->dateTimeBetween('-30 days', 'now');
+
+        return [
+            'dataset_id' => Dataset::factory(),
+            'snapshot_id' => fake()->boolean(70) ? DatasetSnapshot::factory() : null,
+            'purpose' => fake()->randomElement(ConsentPurpose::cases()),
+            'jurisdiction' => fake()->randomElement(Jurisdiction::cases()),
+            'as_of' => $asOf,
+            'subjects_total' => $subjectsTotal,
+            'subjects_with_valid_consent' => $subjectsWithConsent,
+            'coverage_pct' => $coveragePct,
+            'evidence_ref' => 'EVD-' . strtoupper(Str::random(10)),
+            'created_at' => $asOf,
+        ];
+    }
+}

--- a/database/migrations/2025_10_28_120000_create_consent_coverages_table.php
+++ b/database/migrations/2025_10_28_120000_create_consent_coverages_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('consent_coverages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('dataset_id')->constrained('datasets')->onDelete('cascade');
+            $table->foreignId('snapshot_id')->nullable()->constrained('dataset_snapshots')->onDelete('set null');
+            $table->string('purpose');
+            $table->string('jurisdiction');
+            $table->timestamp('as_of');
+            $table->unsignedBigInteger('subjects_total');
+            $table->unsignedBigInteger('subjects_with_valid_consent');
+            $table->decimal('coverage_pct', 5, 2); // 0.00 to 100.00
+            $table->string('evidence_ref');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('consent_coverages');
+    }
+};

--- a/routes/api/user.php
+++ b/routes/api/user.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\User\DatasetSnapshotController;
 use App\Http\Controllers\User\AiModelDatasetController;
 use App\Http\Controllers\User\UserConsentController;
 use App\Http\Controllers\User\ConsentScopeController;
+use App\Http\Controllers\User\ConsentCoverageController;
 
 Route::middleware(['auth:supabase'])->group(function () {
     Route::prefix('/plans')->controller(BillingController::class)->group(function () {
@@ -160,5 +161,13 @@ Route::middleware(['auth:supabase'])->group(function () {
         Route::get('{consentScope}', 'show');
         Route::put('{consentScope}', 'update');
         Route::delete('{consentScope}', 'destroy');
+    });
+
+    Route::prefix('consent-coverages')->controller(ConsentCoverageController::class)->group(function () {
+        Route::get('', 'index');
+        Route::post('', 'store');
+        Route::get('{consentCoverage}', 'show');
+        Route::post('{consentCoverage}', 'update');
+        Route::delete('{consentCoverage}', 'destroy');
     });
 });

--- a/tests/Feature/Controllers/User/ConsentCoverageControllerTest.php
+++ b/tests/Feature/Controllers/User/ConsentCoverageControllerTest.php
@@ -1,0 +1,635 @@
+<?php
+
+namespace Tests\Feature\Controllers\User;
+
+use App\Enums\UserConsent\ConsentPurpose;
+use App\Enums\UserConsent\Jurisdiction;
+use App\Models\ConsentCoverage;
+use App\Models\Dataset;
+use App\Models\DatasetSnapshot;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConsentCoverageControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    private function validPayload(array $overrides = []): array
+    {
+        $dataset = Dataset::factory()->create();
+
+        return array_merge([
+            'dataset_id' => $dataset->id,
+            'snapshot_id' => DatasetSnapshot::factory()->for($dataset)->create()->id,
+            'purpose' => ConsentPurpose::MARKETING->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+            'as_of' => now()->format('Y-m-d H:i:s'),
+            'subjects_total' => 10000,
+            'subjects_with_valid_consent' => 8500,
+            'coverage_pct' => 85.00,
+            'evidence_ref' => 'EVD-' . uniqid(),
+        ], $overrides);
+    }
+
+    /**
+     * Test user can get paginated consent coverages.
+     */
+    public function test_user_can_get_paginated_consent_coverages(): void
+    {
+        ConsentCoverage::factory()->count(20)->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/consent-coverages');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'error',
+                'message',
+                'data' => [
+                    'current_page',
+                    'data' => [
+                        '*' => [
+                            'id',
+                            'dataset_id',
+                            'snapshot_id',
+                            'purpose',
+                            'jurisdiction',
+                            'as_of',
+                            'subjects_total',
+                            'subjects_with_valid_consent',
+                            'coverage_pct',
+                            'evidence_ref',
+                            'created_at',
+                        ]
+                    ],
+                    'per_page',
+                    'total',
+                ]
+            ])
+            ->assertJson(['error' => false]);
+    }
+
+    /**
+     * Test user can get paginated consent coverages with custom per_page.
+     */
+    public function test_user_can_get_paginated_consent_coverages_with_custom_per_page(): void
+    {
+        ConsentCoverage::factory()->count(20)->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/consent-coverages?per_page=10');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.per_page', 10);
+    }
+
+    /**
+     * Test user can create a consent coverage with all fields.
+     */
+    public function test_user_can_create_consent_coverage_with_all_fields(): void
+    {
+        $payload = $this->validPayload();
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'error',
+                'message',
+                'data' => [
+                    'id',
+                    'dataset_id',
+                    'snapshot_id',
+                    'purpose',
+                    'jurisdiction',
+                    'subjects_total',
+                    'subjects_with_valid_consent',
+                    'coverage_pct',
+                ]
+            ])
+            ->assertJson([
+                'error' => false,
+                'message' => 'Consent coverage created successfully',
+                'data' => [
+                    'dataset_id' => $payload['dataset_id'],
+                    'purpose' => $payload['purpose'],
+                    'jurisdiction' => $payload['jurisdiction'],
+                    'subjects_total' => $payload['subjects_total'],
+                    'subjects_with_valid_consent' => $payload['subjects_with_valid_consent'],
+                    'coverage_pct' => $payload['coverage_pct'],
+                ]
+            ]);
+
+        $this->assertDatabaseHas('consent_coverages', [
+            'dataset_id' => $payload['dataset_id'],
+            'subjects_total' => $payload['subjects_total'],
+        ]);
+    }
+
+    /**
+     * Test user can create a consent coverage without snapshot_id.
+     */
+    public function test_user_can_create_consent_coverage_without_snapshot(): void
+    {
+        $payload = $this->validPayload(['snapshot_id' => null]);
+        unset($payload['snapshot_id']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'error' => false,
+                'message' => 'Consent coverage created successfully',
+            ]);
+    }
+
+    /**
+     * Test create validates dataset_id is required.
+     */
+    public function test_create_validates_dataset_id_required(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['dataset_id']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('dataset_id');
+    }
+
+    /**
+     * Test create validates dataset_id exists.
+     */
+    public function test_create_validates_dataset_id_exists(): void
+    {
+        $payload = $this->validPayload(['dataset_id' => 999999]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('dataset_id');
+    }
+
+    /**
+     * Test create validates snapshot_id exists if provided.
+     */
+    public function test_create_validates_snapshot_id_exists(): void
+    {
+        $payload = $this->validPayload(['snapshot_id' => 999999]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('snapshot_id');
+    }
+
+    /**
+     * Test create validates purpose is required.
+     */
+    public function test_create_validates_purpose_required(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['purpose']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('purpose');
+    }
+
+    /**
+     * Test create validates purpose is valid enum.
+     */
+    public function test_create_validates_purpose_enum(): void
+    {
+        $payload = $this->validPayload(['purpose' => 'invalid_purpose']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('purpose');
+    }
+
+    /**
+     * Test create validates jurisdiction is required.
+     */
+    public function test_create_validates_jurisdiction_required(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['jurisdiction']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('jurisdiction');
+    }
+
+    /**
+     * Test create validates jurisdiction is valid enum.
+     */
+    public function test_create_validates_jurisdiction_enum(): void
+    {
+        $payload = $this->validPayload(['jurisdiction' => 'INVALID']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('jurisdiction');
+    }
+
+    /**
+     * Test create validates as_of is required.
+     */
+    public function test_create_validates_as_of_required(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['as_of']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('as_of');
+    }
+
+    /**
+     * Test create validates as_of is valid date.
+     */
+    public function test_create_validates_as_of_is_date(): void
+    {
+        $payload = $this->validPayload(['as_of' => 'not-a-date']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('as_of');
+    }
+
+    /**
+     * Test create validates subjects_total is required.
+     */
+    public function test_create_validates_subjects_total_required(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['subjects_total']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subjects_total');
+    }
+
+    /**
+     * Test create validates subjects_total is integer.
+     */
+    public function test_create_validates_subjects_total_is_integer(): void
+    {
+        $payload = $this->validPayload(['subjects_total' => 'not-a-number']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subjects_total');
+    }
+
+    /**
+     * Test create validates subjects_total is not negative.
+     */
+    public function test_create_validates_subjects_total_min_zero(): void
+    {
+        $payload = $this->validPayload(['subjects_total' => -100]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subjects_total');
+    }
+
+    /**
+     * Test create validates subjects_with_valid_consent is required.
+     */
+    public function test_create_validates_subjects_with_valid_consent_required(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['subjects_with_valid_consent']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subjects_with_valid_consent');
+    }
+
+    /**
+     * Test create validates subjects_with_valid_consent is not negative.
+     */
+    public function test_create_validates_subjects_with_valid_consent_min_zero(): void
+    {
+        $payload = $this->validPayload(['subjects_with_valid_consent' => -50]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subjects_with_valid_consent');
+    }
+
+    /**
+     * Test create validates subjects_with_valid_consent does not exceed subjects_total.
+     */
+    public function test_create_validates_subjects_with_consent_not_exceeding_total(): void
+    {
+        $payload = $this->validPayload([
+            'subjects_total' => 1000,
+            'subjects_with_valid_consent' => 1500,
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subjects_with_valid_consent');
+    }
+
+    /**
+     * Test create validates coverage_pct is required.
+     */
+    public function test_create_validates_coverage_pct_required(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['coverage_pct']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('coverage_pct');
+    }
+
+    /**
+     * Test create validates coverage_pct is numeric.
+     */
+    public function test_create_validates_coverage_pct_is_numeric(): void
+    {
+        $payload = $this->validPayload(['coverage_pct' => 'not-a-number']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('coverage_pct');
+    }
+
+    /**
+     * Test create validates coverage_pct min value.
+     */
+    public function test_create_validates_coverage_pct_min_zero(): void
+    {
+        $payload = $this->validPayload(['coverage_pct' => -10]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('coverage_pct');
+    }
+
+    /**
+     * Test create validates coverage_pct max value.
+     */
+    public function test_create_validates_coverage_pct_max_hundred(): void
+    {
+        $payload = $this->validPayload(['coverage_pct' => 150]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('coverage_pct');
+    }
+
+    /**
+     * Test create validates evidence_ref is required.
+     */
+    public function test_create_validates_evidence_ref_required(): void
+    {
+        $payload = $this->validPayload(['evidence_ref' => '']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('evidence_ref');
+    }
+
+    /**
+     * Test user can show a specific consent coverage.
+     */
+    public function test_user_can_show_specific_consent_coverage(): void
+    {
+        $coverage = ConsentCoverage::factory()->create();
+
+        $response = $this->actingAs($this->user)->getJson("/api/consent-coverages/{$coverage->id}");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'error' => false,
+                'message' => 'Consent coverage retrieved successfully',
+                'data' => [
+                    'id' => $coverage->id,
+                    'dataset_id' => $coverage->dataset_id,
+                ]
+            ]);
+    }
+
+    /**
+     * Test user can update a consent coverage.
+     */
+    public function test_user_can_update_consent_coverage(): void
+    {
+        $coverage = ConsentCoverage::factory()->create([
+            'subjects_total' => 1000,
+            'subjects_with_valid_consent' => 800,
+            'coverage_pct' => 80.00,
+        ]);
+
+        $updatePayload = [
+            'subjects_total' => 1200,
+            'subjects_with_valid_consent' => 1100,
+            'coverage_pct' => 91.67,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson("/api/consent-coverages/{$coverage->id}", $updatePayload);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'error' => false,
+                'message' => 'Consent coverage updated successfully',
+                'data' => [
+                    'id' => $coverage->id,
+                    'subjects_total' => 1200,
+                    'subjects_with_valid_consent' => 1100,
+                    'coverage_pct' => 91.67,
+                ]
+            ]);
+
+        $this->assertDatabaseHas('consent_coverages', [
+            'id' => $coverage->id,
+            'subjects_total' => 1200,
+        ]);
+    }
+
+    /**
+     * Test user can partially update consent coverage.
+     */
+    public function test_user_can_partially_update_consent_coverage(): void
+    {
+        $coverage = ConsentCoverage::factory()->create([
+            'purpose' => ConsentPurpose::MARKETING->value,
+            'coverage_pct' => 75.00,
+        ]);
+
+        $updatePayload = [
+            'coverage_pct' => 85.54,
+        ];
+
+
+        $response = $this->actingAs($this->user)->postJson("/api/consent-coverages/{$coverage->id}", $updatePayload);
+        $response->assertStatus(200)
+            ->assertJsonPath('data.coverage_pct', 85.54)
+            ->assertJsonPath('data.purpose', ConsentPurpose::MARKETING->value);
+    }
+
+    /**
+     * Test user can delete a consent coverage.
+     */
+    public function test_user_can_delete_consent_coverage(): void
+    {
+        $coverage = ConsentCoverage::factory()->create();
+
+        $response = $this->actingAs($this->user)->deleteJson("/api/consent-coverages/{$coverage->id}");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'error' => false,
+                'message' => 'Consent coverage deleted successfully',
+                'data' => null,
+            ]);
+
+        $this->assertDatabaseMissing('consent_coverages', ['id' => $coverage->id]);
+    }
+
+    /**
+     * Test unauthenticated user cannot access index.
+     */
+    public function test_unauthenticated_user_cannot_access_index(): void
+    {
+        $response = $this->getJson('/api/consent-coverages');
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * Test unauthenticated user cannot create coverage.
+     */
+    public function test_unauthenticated_user_cannot_create_coverage(): void
+    {
+        $payload = $this->validPayload();
+
+        $response = $this->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * Test unauthenticated user cannot update coverage.
+     */
+    public function test_unauthenticated_user_cannot_update_coverage(): void
+    {
+        $coverage = ConsentCoverage::factory()->create();
+
+        $response = $this->postJson("/api/consent-coverages/{$coverage->id}", [
+            'coverage_pct' => 95.00,
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * Test unauthenticated user cannot delete coverage.
+     */
+    public function test_unauthenticated_user_cannot_delete_coverage(): void
+    {
+        $coverage = ConsentCoverage::factory()->create();
+
+        $response = $this->deleteJson("/api/consent-coverages/{$coverage->id}");
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * Test show returns 404 for non-existent coverage.
+     */
+    public function test_show_returns_404_for_non_existent_coverage(): void
+    {
+        $response = $this->actingAs($this->user)->getJson('/api/consent-coverages/999999');
+
+        $response->assertStatus(404);
+    }
+
+    /**
+     * Test create handles all consent purposes.
+     */
+    public function test_create_handles_all_consent_purposes(): void
+    {
+        $purposes = [
+            ConsentPurpose::MARKETING,
+            ConsentPurpose::ANALYTICS,
+            ConsentPurpose::PERSONALIZATION,
+            ConsentPurpose::TRAINING_AI,
+            ConsentPurpose::SERVICE_OPERATIONS,
+        ];
+
+        foreach ($purposes as $purpose) {
+            $payload = $this->validPayload(['purpose' => $purpose->value]);
+            $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+            $response->assertStatus(201);
+        }
+    }
+
+    /**
+     * Test create handles all jurisdictions.
+     */
+    public function test_create_handles_all_jurisdictions(): void
+    {
+        $jurisdictions = [
+            Jurisdiction::AE,
+            Jurisdiction::EU,
+            Jurisdiction::KSA,
+            Jurisdiction::US,
+            Jurisdiction::UK,
+        ];
+
+        foreach ($jurisdictions as $jurisdiction) {
+            $payload = $this->validPayload(['jurisdiction' => $jurisdiction->value]);
+            $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+            $response->assertStatus(201);
+        }
+    }
+
+    /**
+     * Test create handles large subject numbers.
+     */
+    public function test_create_handles_large_numbers(): void
+    {
+        $payload = $this->validPayload([
+            'subjects_total' => 10000000,
+            'subjects_with_valid_consent' => 9500000,
+            'coverage_pct' => 95.00,
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/consent-coverages', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.subjects_total', 10000000)
+            ->assertJsonPath('data.subjects_with_valid_consent', 9500000);
+    }
+}

--- a/tests/Feature/Repositories/ConsentCoverageRepositoryTest.php
+++ b/tests/Feature/Repositories/ConsentCoverageRepositoryTest.php
@@ -1,0 +1,401 @@
+<?php
+
+namespace Tests\Feature\Repositories;
+
+use App\Enums\UserConsent\ConsentPurpose;
+use App\Enums\UserConsent\Jurisdiction;
+use App\Models\ConsentCoverage;
+use App\Models\Dataset;
+use App\Models\DatasetSnapshot;
+use App\Repositories\ConsentCoverageRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ConsentCoverageRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ConsentCoverageRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new ConsentCoverageRepository();
+    }
+
+    /**
+     * Test get paginated coverages returns correct structure.
+     */
+    public function test_get_paginated_coverages_returns_paginator(): void
+    {
+        ConsentCoverage::factory()->count(5)->create();
+
+        $result = $this->repository->getPaginatedCoverages();
+
+        $this->assertInstanceOf(\Illuminate\Contracts\Pagination\LengthAwarePaginator::class, $result);
+        $this->assertEquals(5, $result->total());
+    }
+
+    /**
+     * Test get paginated coverages eager loads relationships.
+     */
+    public function test_get_paginated_coverages_eager_loads_relationships(): void
+    {
+        $dataset = Dataset::factory()->create();
+        $snapshot = DatasetSnapshot::factory()->for($dataset)->create();
+        ConsentCoverage::factory()->for($dataset)->for($snapshot, 'snapshot')->create();
+
+        $result = $this->repository->getPaginatedCoverages();
+
+        /** @var ConsentCoverage $coverage */
+        $coverage = $result->items()[0];
+        $this->assertTrue($coverage->relationLoaded('dataset'));
+        $this->assertTrue($coverage->relationLoaded('snapshot'));
+        $this->assertEquals($dataset->id, $coverage->dataset->id);
+        $this->assertEquals($snapshot->id, $coverage->snapshot->id);
+    }
+
+    /**
+     * Test get paginated coverages respects per page parameter.
+     */
+    public function test_get_paginated_coverages_respects_per_page(): void
+    {
+        ConsentCoverage::factory()->count(20)->create();
+
+        $result = $this->repository->getPaginatedCoverages(10);
+
+        $this->assertEquals(10, $result->perPage());
+        $this->assertCount(10, $result->items());
+        $this->assertEquals(20, $result->total());
+    }
+
+    /**
+     * Test get paginated coverages with default per page.
+     */
+    public function test_get_paginated_coverages_uses_default_per_page(): void
+    {
+        ConsentCoverage::factory()->count(20)->create();
+
+        $result = $this->repository->getPaginatedCoverages();
+
+        $this->assertEquals(15, $result->perPage());
+    }
+
+    /**
+     * Test get paginated coverages orders by as_of desc.
+     */
+    public function test_get_paginated_coverages_ordered_by_as_of_desc(): void
+    {
+        $coverage1 = ConsentCoverage::factory()->create(['as_of' => now()->subDays(3)]);
+        $coverage2 = ConsentCoverage::factory()->create(['as_of' => now()->subDays(1)]);
+        $coverage3 = ConsentCoverage::factory()->create(['as_of' => now()->subDays(2)]);
+
+        $result = $this->repository->getPaginatedCoverages();
+
+        $this->assertEquals($coverage2->id, $result->items()[0]->id);
+        $this->assertEquals($coverage3->id, $result->items()[1]->id);
+        $this->assertEquals($coverage1->id, $result->items()[2]->id);
+    }
+
+    /**
+     * Test create coverage creates a new coverage.
+     */
+    public function test_create_coverage_creates_new_coverage(): void
+    {
+        $dataset = Dataset::factory()->create();
+        $snapshot = DatasetSnapshot::factory()->for($dataset)->create();
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'snapshot_id' => $snapshot->id,
+            'purpose' => ConsentPurpose::MARKETING->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+            'as_of' => now(),
+            'subjects_total' => 10000,
+            'subjects_with_valid_consent' => 8500,
+            'coverage_pct' => 85.00,
+            'evidence_ref' => 'EVD-TEST-001',
+        ];
+
+        $result = $this->repository->createCoverage($data);
+
+        $this->assertInstanceOf(ConsentCoverage::class, $result);
+        $this->assertEquals($data['dataset_id'], $result->dataset_id);
+        $this->assertEquals($data['snapshot_id'], $result->snapshot_id);
+        $this->assertEquals($data['purpose'], $result->purpose);
+        $this->assertEquals($data['subjects_total'], $result->subjects_total);
+        $this->assertEquals($data['subjects_with_valid_consent'], $result->subjects_with_valid_consent);
+        $this->assertEquals($data['coverage_pct'], (float) $result->coverage_pct);
+        $this->assertDatabaseHas('consent_coverages', [
+            'dataset_id' => $dataset->id,
+            'subjects_total' => 10000,
+        ]);
+    }
+
+    /**
+     * Test create coverage with minimal required data.
+     */
+    public function test_create_coverage_with_minimal_data(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'purpose' => ConsentPurpose::ANALYTICS->value,
+            'jurisdiction' => Jurisdiction::US->value,
+            'as_of' => now(),
+            'subjects_total' => 5000,
+            'subjects_with_valid_consent' => 5000,
+            'coverage_pct' => 100.00,
+            'evidence_ref' => 'EVD-FULL',
+        ];
+
+        $result = $this->repository->createCoverage($data);
+
+        $this->assertInstanceOf(ConsentCoverage::class, $result);
+        $this->assertNull($result->snapshot_id);
+        $this->assertEquals(100.00, (float) $result->coverage_pct);
+    }
+
+    /**
+     * Test create coverage automatically sets created_at if not provided.
+     */
+    public function test_create_coverage_sets_created_at_automatically(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'purpose' => ConsentPurpose::MARKETING->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+            'as_of' => now(),
+            'subjects_total' => 1000,
+            'subjects_with_valid_consent' => 900,
+            'coverage_pct' => 90.00,
+            'evidence_ref' => 'EVD-AUTO',
+        ];
+
+        $result = $this->repository->createCoverage($data);
+
+        $this->assertNotNull($result->created_at);
+    }
+
+    /**
+     * Test update coverage updates existing coverage.
+     */
+    public function test_update_coverage_updates_existing_coverage(): void
+    {
+        $coverage = ConsentCoverage::factory()->create([
+            'subjects_total' => 1000,
+            'subjects_with_valid_consent' => 800,
+            'coverage_pct' => 80.00,
+        ]);
+
+        $updateData = [
+            'subjects_total' => 1200,
+            'subjects_with_valid_consent' => 1100,
+            'coverage_pct' => 91.67,
+        ];
+
+        $result = $this->repository->updateCoverage($coverage, $updateData);
+
+        $this->assertTrue($result);
+        $coverage->refresh();
+        $this->assertEquals(1200, $coverage->subjects_total);
+        $this->assertEquals(1100, $coverage->subjects_with_valid_consent);
+        $this->assertEquals(91.67, (float) $coverage->coverage_pct);
+    }
+
+    /**
+     * Test update coverage can change purpose and jurisdiction.
+     */
+    public function test_update_coverage_can_change_purpose_and_jurisdiction(): void
+    {
+        $coverage = ConsentCoverage::factory()->create([
+            'purpose' => ConsentPurpose::MARKETING->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+        ]);
+
+        $this->repository->updateCoverage($coverage, [
+            'purpose' => ConsentPurpose::TRAINING_AI->value,
+            'jurisdiction' => Jurisdiction::US->value,
+        ]);
+
+        $coverage->refresh();
+        $this->assertEquals(ConsentPurpose::TRAINING_AI->value, $coverage->purpose);
+        $this->assertEquals(Jurisdiction::US->value, $coverage->jurisdiction);
+    }
+
+    /**
+     * Test delete coverage deletes the coverage.
+     */
+    public function test_delete_coverage_deletes_coverage(): void
+    {
+        $coverage = ConsentCoverage::factory()->create();
+        $coverageId = $coverage->id;
+
+        $result = $this->repository->deleteCoverage($coverage);
+
+        $this->assertTrue($result);
+        $this->assertDatabaseMissing('consent_coverages', ['id' => $coverageId]);
+    }
+
+    /**
+     * Test delete coverage returns false on failure.
+     */
+    public function test_delete_coverage_returns_false_on_failure(): void
+    {
+        $coverage = ConsentCoverage::factory()->create();
+
+        // Delete it first
+        $coverage->delete();
+
+        // Try to delete again - should return false
+        $result = $this->repository->deleteCoverage($coverage);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test coverage with different purposes.
+     */
+    public function test_repository_handles_all_purposes(): void
+    {
+        $purposes = [
+            ConsentPurpose::MARKETING,
+            ConsentPurpose::ANALYTICS,
+            ConsentPurpose::PERSONALIZATION,
+            ConsentPurpose::TRAINING_AI,
+        ];
+
+        foreach ($purposes as $purpose) {
+            $coverage = ConsentCoverage::factory()->create(['purpose' => $purpose->value]);
+            $this->assertEquals($purpose->value, $coverage->purpose);
+        }
+    }
+
+    /**
+     * Test coverage with different jurisdictions.
+     */
+    public function test_repository_handles_all_jurisdictions(): void
+    {
+        $jurisdictions = [
+            Jurisdiction::AE,
+            Jurisdiction::EU,
+            Jurisdiction::KSA,
+            Jurisdiction::US,
+            Jurisdiction::UK,
+        ];
+
+        foreach ($jurisdictions as $jurisdiction) {
+            $coverage = ConsentCoverage::factory()->create(['jurisdiction' => $jurisdiction->value]);
+            $this->assertEquals($jurisdiction->value, $coverage->jurisdiction);
+        }
+    }
+
+    /**
+     * Test coverage with zero coverage percentage.
+     */
+    public function test_create_coverage_with_zero_coverage(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'purpose' => ConsentPurpose::MARKETING->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+            'as_of' => now(),
+            'subjects_total' => 1000,
+            'subjects_with_valid_consent' => 0,
+            'coverage_pct' => 0.00,
+            'evidence_ref' => 'EVD-ZERO',
+        ];
+
+        $result = $this->repository->createCoverage($data);
+
+        $this->assertEquals(0.00, (float) $result->coverage_pct);
+    }
+
+    /**
+     * Test coverage with 100% coverage.
+     */
+    public function test_create_coverage_with_full_coverage(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'purpose' => ConsentPurpose::ANALYTICS->value,
+            'jurisdiction' => Jurisdiction::US->value,
+            'as_of' => now(),
+            'subjects_total' => 5000,
+            'subjects_with_valid_consent' => 5000,
+            'coverage_pct' => 100.00,
+            'evidence_ref' => 'EVD-FULL',
+        ];
+
+        $result = $this->repository->createCoverage($data);
+
+        $this->assertEquals(100.00, (float) $result->coverage_pct);
+    }
+
+    /**
+     * Test coverage handles large numbers.
+     */
+    public function test_create_coverage_with_large_numbers(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'purpose' => ConsentPurpose::TRAINING_AI->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+            'as_of' => now(),
+            'subjects_total' => 10000000,
+            'subjects_with_valid_consent' => 9500000,
+            'coverage_pct' => 95.00,
+            'evidence_ref' => 'EVD-LARGE',
+        ];
+
+        $result = $this->repository->createCoverage($data);
+
+        $this->assertEquals(10000000, $result->subjects_total);
+        $this->assertEquals(9500000, $result->subjects_with_valid_consent);
+    }
+
+    /**
+     * Test coverage preserves decimal precision.
+     */
+    public function test_coverage_preserves_decimal_precision(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'purpose' => ConsentPurpose::MARKETING->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+            'as_of' => now(),
+            'subjects_total' => 1000,
+            'subjects_with_valid_consent' => 857,
+            'coverage_pct' => 85.70,
+            'evidence_ref' => 'EVD-PRECISION',
+        ];
+
+        $result = $this->repository->createCoverage($data);
+
+        $this->assertEquals(85.70, (float) $result->coverage_pct);
+    }
+
+    /**
+     * Test repository handles nullable snapshot_id.
+     */
+    public function test_repository_handles_nullable_snapshot_id(): void
+    {
+        $coverage = ConsentCoverage::factory()->create([
+            'snapshot_id' => null,
+        ]);
+
+        $this->assertNull($coverage->snapshot_id);
+        $this->assertInstanceOf(ConsentCoverage::class, $coverage);
+    }
+}


### PR DESCRIPTION
- Implemented StoreConsentCoverageRequest and UpdateConsentCoverageRequest for validation of consent coverage data.
- Created ConsentCoverage model with relationships to Dataset and DatasetSnapshot.
- Developed ConsentCoverageRepository for handling CRUD operations and pagination of consent coverages.
- Added ConsentCoverageResource for transforming consent coverage data into JSON format.
- Created database migration for consent_coverages table.
- Developed tests for ConsentCoverageController and ConsentCoverageRepository to ensure functionality and validation rules.
- Added routes for consent coverage management in the API.