### PR TITLE
feat: Add DatasetSubjectPopulation management functionality

### DIFF
--- a/app/Http/Controllers/User/DatasetSubjectPopulationController.php
+++ b/app/Http/Controllers/User/DatasetSubjectPopulationController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\User;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\DatasetSubjectPopulation\StoreDatasetSubjectPopulationRequest;
+use App\Http\Requests\DatasetSubjectPopulation\UpdateDatasetSubjectPopulationRequest;
+use App\Http\Resources\DatasetSubjectPopulationResource;
+use App\Models\DatasetSubjectPopulation;
+use App\Repositories\DatasetSubjectPopulationRepository;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DatasetSubjectPopulationController extends Controller
+{
+    public function __construct(
+        private readonly DatasetSubjectPopulationRepository $repository
+    ) {}
+
+    /**
+     * Display a paginated listing of dataset subject populations.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = $request->input('per_page', 15);
+        $populations = $this->repository->getPaginatedPopulations($perPage);
+
+        return response()->json([
+            'error' => false,
+            'message' => 'Dataset subject populations retrieved successfully',
+            'data' => $populations,
+        ]);
+    }
+
+    /**
+     * Store a newly created dataset subject population.
+     */
+    public function store(StoreDatasetSubjectPopulationRequest $request): JsonResponse
+    {
+        $population = $this->repository->createPopulation($request->validated());
+
+        return response()->json([
+            'error' => false,
+            'message' => 'Dataset subject population created successfully',
+            'data' => new DatasetSubjectPopulationResource($population),
+        ], 201);
+    }
+
+    /**
+     * Display the specified dataset subject population.
+     */
+    public function show(DatasetSubjectPopulation $datasetSubjectPopulation): JsonResponse
+    {
+        return response()->json([
+            'error' => false,
+            'message' => 'Dataset subject population retrieved successfully',
+            'data' => new DatasetSubjectPopulationResource($datasetSubjectPopulation),
+        ]);
+    }
+
+    /**
+     * Update the specified dataset subject population.
+     */
+    public function update(
+        UpdateDatasetSubjectPopulationRequest $request,
+        DatasetSubjectPopulation $datasetSubjectPopulation
+    ): JsonResponse {
+        $population = $this->repository->updatePopulation($datasetSubjectPopulation, $request->validated());
+
+        return response()->json([
+            'error' => false,
+            'message' => 'Dataset subject population updated successfully',
+            'data' => new DatasetSubjectPopulationResource($population),
+        ]);
+    }
+
+    /**
+     * Remove the specified dataset subject population.
+     */
+    public function destroy(DatasetSubjectPopulation $datasetSubjectPopulation): JsonResponse
+    {
+        $this->repository->deletePopulation($datasetSubjectPopulation);
+
+        return response()->json([
+            'error' => false,
+            'message' => 'Dataset subject population deleted successfully',
+            'data' => null,
+        ]);
+    }
+}

--- a/app/Http/Requests/DatasetSubjectPopulation/StoreDatasetSubjectPopulationRequest.php
+++ b/app/Http/Requests/DatasetSubjectPopulation/StoreDatasetSubjectPopulationRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\DatasetSubjectPopulation;
+
+use App\Enums\UserConsent\Jurisdiction;
+use App\Enums\UserConsent\SubjectRealm;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreDatasetSubjectPopulationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'dataset_id' => ['required', 'integer', 'exists:datasets,id'],
+            'snapshot_id' => ['nullable', 'integer', 'exists:dataset_snapshots,id'],
+            'subject_realm' => ['required', 'string', Rule::enum(SubjectRealm::class)],
+            'jurisdiction' => ['required', 'string', Rule::enum(Jurisdiction::class)],
+            'subjects_total' => ['required', 'integer', 'min:0'],
+            'as_of' => ['required', 'date'],
+        ];
+    }
+}

--- a/app/Http/Requests/DatasetSubjectPopulation/UpdateDatasetSubjectPopulationRequest.php
+++ b/app/Http/Requests/DatasetSubjectPopulation/UpdateDatasetSubjectPopulationRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\DatasetSubjectPopulation;
+
+use App\Enums\UserConsent\Jurisdiction;
+use App\Enums\UserConsent\SubjectRealm;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateDatasetSubjectPopulationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'dataset_id' => ['sometimes', 'integer', 'exists:datasets,id'],
+            'snapshot_id' => ['nullable', 'integer', 'exists:dataset_snapshots,id'],
+            'subject_realm' => ['sometimes', 'string', Rule::enum(SubjectRealm::class)],
+            'jurisdiction' => ['sometimes', 'string', Rule::enum(Jurisdiction::class)],
+            'subjects_total' => ['sometimes', 'integer', 'min:0'],
+            'as_of' => ['sometimes', 'date'],
+        ];
+    }
+}

--- a/app/Http/Resources/DatasetSubjectPopulationResource.php
+++ b/app/Http/Resources/DatasetSubjectPopulationResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\DatasetSubjectPopulation
+ */
+class DatasetSubjectPopulationResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'dataset_id' => $this->dataset_id,
+            'snapshot_id' => $this->snapshot_id,
+            'subject_realm' => $this->subject_realm,
+            'jurisdiction' => $this->jurisdiction,
+            'subjects_total' => $this->subjects_total,
+            'as_of' => Carbon::parse($this->as_of)->toIso8601String(),
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/DatasetSubjectPopulation.php
+++ b/app/Models/DatasetSubjectPopulation.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DatasetSubjectPopulation extends Model
+{
+    /** @use HasFactory<\Database\Factories\DatasetSubjectPopulationFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'dataset_id',
+        'snapshot_id',
+        'subject_realm',
+        'jurisdiction',
+        'subjects_total',
+        'as_of',
+    ];
+
+    protected $casts = [
+        'subjects_total' => 'integer',
+        'as_of' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<Dataset, $this>
+     */
+    public function dataset(): BelongsTo
+    {
+        return $this->belongsTo(Dataset::class);
+    }
+
+    /**
+     * @return BelongsTo<DatasetSnapshot, $this>
+     */
+    public function snapshot(): BelongsTo
+    {
+        return $this->belongsTo(DatasetSnapshot::class, 'snapshot_id');
+    }
+}

--- a/app/Repositories/DatasetSubjectPopulationRepository.php
+++ b/app/Repositories/DatasetSubjectPopulationRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\DatasetSubjectPopulation;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class DatasetSubjectPopulationRepository
+{
+    /**
+     * @return LengthAwarePaginator<int, DatasetSubjectPopulation>
+     */
+    public function getPaginatedPopulations(int $perPage = 15): LengthAwarePaginator
+    {
+        return DatasetSubjectPopulation::with(['dataset', 'snapshot'])
+            ->orderBy('as_of', 'desc')
+            ->paginate($perPage);
+    }
+
+    /**
+     * Create a new dataset subject population record.
+     */
+    public function createPopulation(array $data): DatasetSubjectPopulation
+    {
+        if (!isset($data['created_at'])) {
+            $data['created_at'] = now();
+        }
+
+        return DatasetSubjectPopulation::create($data);
+    }
+
+    /**
+     * Update an existing dataset subject population record.
+     */
+    public function updatePopulation(DatasetSubjectPopulation $population, array $data): DatasetSubjectPopulation
+    {
+        $population->update($data);
+        return $population->fresh();
+    }
+
+    /**
+     * Delete a dataset subject population record.
+     */
+    public function deletePopulation(DatasetSubjectPopulation $population): bool
+    {
+        return $population->delete();
+    }
+}

--- a/database/factories/DatasetSubjectPopulationFactory.php
+++ b/database/factories/DatasetSubjectPopulationFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\UserConsent\Jurisdiction;
+use App\Enums\UserConsent\SubjectRealm;
+use App\Models\Dataset;
+use App\Models\DatasetSnapshot;
+use App\Models\DatasetSubjectPopulation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DatasetSubjectPopulation>
+ */
+class DatasetSubjectPopulationFactory extends Factory
+{
+    protected $model = DatasetSubjectPopulation::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'dataset_id' => Dataset::factory(),
+            'snapshot_id' => $this->faker->boolean(70) ? DatasetSnapshot::factory() : null,
+            'subject_realm' => $this->faker->randomElement(SubjectRealm::cases())->value,
+            'jurisdiction' => $this->faker->randomElement(Jurisdiction::cases())->value,
+            'subjects_total' => $this->faker->numberBetween(1000, 1000000),
+            'as_of' => $this->faker->dateTimeBetween('-6 months', 'now'),
+        ];
+    }
+}

--- a/database/migrations/2025_10_28_130000_create_dataset_subject_populations_table.php
+++ b/database/migrations/2025_10_28_130000_create_dataset_subject_populations_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('dataset_subject_populations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('dataset_id')->constrained('datasets')->onDelete('cascade');
+            $table->foreignId('snapshot_id')->nullable()->constrained('dataset_snapshots')->onDelete('cascade');
+            $table->string('subject_realm');
+            $table->string('jurisdiction');
+            $table->bigInteger('subjects_total')->unsigned();
+            $table->timestamp('as_of');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('dataset_subject_populations');
+    }
+};

--- a/routes/api/user.php
+++ b/routes/api/user.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\User\AiModelDatasetController;
 use App\Http\Controllers\User\UserConsentController;
 use App\Http\Controllers\User\ConsentScopeController;
 use App\Http\Controllers\User\ConsentCoverageController;
+use App\Http\Controllers\User\DatasetSubjectPopulationController;
 
 Route::middleware(['auth:supabase'])->group(function () {
     Route::prefix('/plans')->controller(BillingController::class)->group(function () {
@@ -169,5 +170,13 @@ Route::middleware(['auth:supabase'])->group(function () {
         Route::get('{consentCoverage}', 'show');
         Route::post('{consentCoverage}', 'update');
         Route::delete('{consentCoverage}', 'destroy');
+    });
+
+    Route::prefix('dataset-subject-populations')->controller(DatasetSubjectPopulationController::class)->group(function () {
+        Route::get('', 'index');
+        Route::post('', 'store');
+        Route::get('{datasetSubjectPopulation}', 'show');
+        Route::post('{datasetSubjectPopulation}', 'update');
+        Route::delete('{datasetSubjectPopulation}', 'destroy');
     });
 });

--- a/tests/Feature/Controllers/User/DatasetSubjectPopulationControllerTest.php
+++ b/tests/Feature/Controllers/User/DatasetSubjectPopulationControllerTest.php
@@ -1,0 +1,586 @@
+<?php
+
+namespace Tests\Feature\Controllers\User;
+
+use App\Enums\UserConsent\Jurisdiction;
+use App\Enums\UserConsent\SubjectRealm;
+use App\Models\Dataset;
+use App\Models\DatasetSnapshot;
+use App\Models\DatasetSubjectPopulation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatasetSubjectPopulationControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    private function validPayload(array $overrides = []): array
+    {
+        $dataset = Dataset::factory()->create();
+
+        return array_merge([
+            'dataset_id' => $dataset->id,
+            'snapshot_id' => DatasetSnapshot::factory()->for($dataset)->create()->id,
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+            'subjects_total' => 10000,
+            'as_of' => now()->format('Y-m-d H:i:s'),
+        ], $overrides);
+    }
+
+    /**
+     * Test user can get paginated dataset subject populations.
+     */
+    public function test_user_can_get_paginated_populations(): void
+    {
+        DatasetSubjectPopulation::factory()->count(20)->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/dataset-subject-populations');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'error',
+                'message',
+                'data' => [
+                    'current_page',
+                    'data' => [
+                        '*' => [
+                            'id',
+                            'dataset_id',
+                            'snapshot_id',
+                            'subject_realm',
+                            'jurisdiction',
+                            'subjects_total',
+                            'as_of',
+                            'created_at',
+                        ]
+                    ],
+                    'per_page',
+                    'total',
+                ]
+            ])
+            ->assertJson(['error' => false]);
+    }
+
+    /**
+     * Test user can get paginated populations with custom per_page.
+     */
+    public function test_user_can_get_paginated_populations_with_custom_per_page(): void
+    {
+        DatasetSubjectPopulation::factory()->count(20)->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/dataset-subject-populations?per_page=10');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.per_page', 10);
+    }
+
+    /**
+     * Test user can create a dataset subject population with all fields.
+     */
+    public function test_user_can_create_population_with_all_fields(): void
+    {
+        $payload = $this->validPayload();
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'error',
+                'message',
+                'data' => [
+                    'id',
+                    'dataset_id',
+                    'snapshot_id',
+                    'subject_realm',
+                    'jurisdiction',
+                    'subjects_total',
+                ]
+            ])
+            ->assertJson([
+                'error' => false,
+                'message' => 'Dataset subject population created successfully',
+                'data' => [
+                    'dataset_id' => $payload['dataset_id'],
+                    'subject_realm' => $payload['subject_realm'],
+                    'jurisdiction' => $payload['jurisdiction'],
+                    'subjects_total' => $payload['subjects_total'],
+                ]
+            ]);
+
+        $this->assertDatabaseHas('dataset_subject_populations', [
+            'dataset_id' => $payload['dataset_id'],
+            'subjects_total' => $payload['subjects_total'],
+        ]);
+    }
+
+    /**
+     * Test user can create a population without snapshot_id.
+     */
+    public function test_user_can_create_population_without_snapshot(): void
+    {
+        $payload = $this->validPayload(['snapshot_id' => null]);
+        unset($payload['snapshot_id']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'error' => false,
+                'message' => 'Dataset subject population created successfully',
+            ]);
+    }
+
+    /**
+     * Test create validates dataset_id is required.
+     */
+    public function test_create_validates_dataset_id_required(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['dataset_id']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('dataset_id');
+    }
+
+    /**
+     * Test create validates dataset_id exists.
+     */
+    public function test_create_validates_dataset_id_exists(): void
+    {
+        $payload = $this->validPayload(['dataset_id' => 999999]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('dataset_id');
+    }
+
+    /**
+     * Test create validates snapshot_id exists if provided.
+     */
+    public function test_create_validates_snapshot_id_exists(): void
+    {
+        $payload = $this->validPayload(['snapshot_id' => 999999]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('snapshot_id');
+    }
+
+    /**
+     * Test create validates subject_realm is required.
+     */
+    public function test_create_validates_subject_realm_required(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['subject_realm']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subject_realm');
+    }
+
+    /**
+     * Test create validates subject_realm is valid enum.
+     */
+    public function test_create_validates_subject_realm_enum(): void
+    {
+        $payload = $this->validPayload(['subject_realm' => 'invalid_realm']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subject_realm');
+    }
+
+    /**
+     * Test create validates jurisdiction is required.
+     */
+    public function test_create_validates_jurisdiction_required(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['jurisdiction']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('jurisdiction');
+    }
+
+    /**
+     * Test create validates jurisdiction is valid enum.
+     */
+    public function test_create_validates_jurisdiction_enum(): void
+    {
+        $payload = $this->validPayload(['jurisdiction' => 'INVALID']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('jurisdiction');
+    }
+
+    /**
+     * Test create validates subjects_total is required.
+     */
+    public function test_create_validates_subjects_total_required(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['subjects_total']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subjects_total');
+    }
+
+    /**
+     * Test create validates subjects_total is integer.
+     */
+    public function test_create_validates_subjects_total_is_integer(): void
+    {
+        $payload = $this->validPayload(['subjects_total' => 'not-a-number']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subjects_total');
+    }
+
+    /**
+     * Test create validates subjects_total is not negative.
+     */
+    public function test_create_validates_subjects_total_min_zero(): void
+    {
+        $payload = $this->validPayload(['subjects_total' => -100]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subjects_total');
+    }
+
+    /**
+     * Test create validates as_of is required.
+     */
+    public function test_create_validates_as_of_required(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['as_of']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('as_of');
+    }
+
+    /**
+     * Test create validates as_of is valid date.
+     */
+    public function test_create_validates_as_of_is_date(): void
+    {
+        $payload = $this->validPayload(['as_of' => 'not-a-date']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('as_of');
+    }
+
+    /**
+     * Test user can show a specific population.
+     */
+    public function test_user_can_show_specific_population(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create();
+
+        $response = $this->actingAs($this->user)->getJson("/api/dataset-subject-populations/{$population->id}");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'error' => false,
+                'message' => 'Dataset subject population retrieved successfully',
+                'data' => [
+                    'id' => $population->id,
+                    'dataset_id' => $population->dataset_id,
+                ]
+            ]);
+    }
+
+    /**
+     * Test user can update a population.
+     */
+    public function test_user_can_update_population(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create([
+            'subjects_total' => 1000,
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+        ]);
+
+        $updatePayload = [
+            'subjects_total' => 2000,
+            'subject_realm' => SubjectRealm::EMPLOYEE->value,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson("/api/dataset-subject-populations/{$population->id}", $updatePayload);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'error' => false,
+                'message' => 'Dataset subject population updated successfully',
+                'data' => [
+                    'id' => $population->id,
+                    'subjects_total' => 2000,
+                    'subject_realm' => SubjectRealm::EMPLOYEE->value,
+                ]
+            ]);
+
+        $this->assertDatabaseHas('dataset_subject_populations', [
+            'id' => $population->id,
+            'subjects_total' => 2000,
+        ]);
+    }
+
+    /**
+     * Test user can partially update population.
+     */
+    public function test_user_can_partially_update_population(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create([
+            'subjects_total' => 1000,
+            'jurisdiction' => Jurisdiction::EU->value,
+        ]);
+
+        $updatePayload = [
+            'subjects_total' => 1500,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson("/api/dataset-subject-populations/{$population->id}", $updatePayload);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.subjects_total', 1500)
+            ->assertJsonPath('data.jurisdiction', Jurisdiction::EU->value);
+    }
+
+    /**
+     * Test user can delete a population.
+     */
+    public function test_user_can_delete_population(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create();
+
+        $response = $this->actingAs($this->user)->deleteJson("/api/dataset-subject-populations/{$population->id}");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'error' => false,
+                'message' => 'Dataset subject population deleted successfully',
+                'data' => null,
+            ]);
+
+        $this->assertDatabaseMissing('dataset_subject_populations', ['id' => $population->id]);
+    }
+
+    /**
+     * Test unauthenticated user cannot access index.
+     */
+    public function test_unauthenticated_user_cannot_access_index(): void
+    {
+        $response = $this->getJson('/api/dataset-subject-populations');
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * Test unauthenticated user cannot create population.
+     */
+    public function test_unauthenticated_user_cannot_create_population(): void
+    {
+        $payload = $this->validPayload();
+
+        $response = $this->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * Test unauthenticated user cannot update population.
+     */
+    public function test_unauthenticated_user_cannot_update_population(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create();
+
+        $response = $this->postJson("/api/dataset-subject-populations/{$population->id}", [
+            'subjects_total' => 5000,
+        ]);
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * Test unauthenticated user cannot delete population.
+     */
+    public function test_unauthenticated_user_cannot_delete_population(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create();
+
+        $response = $this->deleteJson("/api/dataset-subject-populations/{$population->id}");
+
+        $response->assertStatus(401);
+    }
+
+    /**
+     * Test show returns 404 for non-existent population.
+     */
+    public function test_show_returns_404_for_non_existent_population(): void
+    {
+        $response = $this->actingAs($this->user)->getJson('/api/dataset-subject-populations/999999');
+
+        $response->assertStatus(404);
+    }
+
+    /**
+     * Test create handles all subject realms.
+     */
+    public function test_create_handles_all_subject_realms(): void
+    {
+        $realms = [
+            SubjectRealm::CUSTOMER,
+            SubjectRealm::PROSPECT,
+            SubjectRealm::EMPLOYEE,
+            SubjectRealm::VENDOR,
+            SubjectRealm::OTHER,
+        ];
+
+        foreach ($realms as $realm) {
+            $payload = $this->validPayload(['subject_realm' => $realm->value]);
+            $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+            $response->assertStatus(201);
+        }
+    }
+
+    /**
+     * Test create handles all jurisdictions.
+     */
+    public function test_create_handles_all_jurisdictions(): void
+    {
+        $jurisdictions = [
+            Jurisdiction::AE,
+            Jurisdiction::EU,
+            Jurisdiction::KSA,
+            Jurisdiction::US,
+            Jurisdiction::UK,
+        ];
+
+        foreach ($jurisdictions as $jurisdiction) {
+            $payload = $this->validPayload(['jurisdiction' => $jurisdiction->value]);
+            $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+            $response->assertStatus(201);
+        }
+    }
+
+    /**
+     * Test create handles zero subjects.
+     */
+    public function test_create_handles_zero_subjects(): void
+    {
+        $payload = $this->validPayload(['subjects_total' => 0]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.subjects_total', 0);
+    }
+
+    /**
+     * Test create handles large subject numbers.
+     */
+    public function test_create_handles_large_numbers(): void
+    {
+        $payload = $this->validPayload([
+            'subjects_total' => 50000000,
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.subjects_total', 50000000);
+    }
+
+    /**
+     * Test create handles past as_of dates.
+     */
+    public function test_create_handles_past_as_of_dates(): void
+    {
+        $pastDate = now()->subMonths(6);
+        $payload = $this->validPayload([
+            'as_of' => $pastDate->format('Y-m-d H:i:s'),
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-subject-populations', $payload);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('dataset_subject_populations', [
+            'dataset_id' => $payload['dataset_id'],
+        ]);
+    }
+
+    /**
+     * Test update validates subjects_total min value.
+     */
+    public function test_update_validates_subjects_total_min_zero(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create();
+
+        $response = $this->actingAs($this->user)->postJson("/api/dataset-subject-populations/{$population->id}", [
+            'subjects_total' => -50,
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subjects_total');
+    }
+
+    /**
+     * Test update validates invalid subject_realm.
+     */
+    public function test_update_validates_invalid_subject_realm(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create();
+
+        $response = $this->actingAs($this->user)->postJson("/api/dataset-subject-populations/{$population->id}", [
+            'subject_realm' => 'invalid_realm',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('subject_realm');
+    }
+
+    /**
+     * Test update validates invalid jurisdiction.
+     */
+    public function test_update_validates_invalid_jurisdiction(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create();
+
+        $response = $this->actingAs($this->user)->postJson("/api/dataset-subject-populations/{$population->id}", [
+            'jurisdiction' => 'INVALID',
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors('jurisdiction');
+    }
+}

--- a/tests/Feature/Repositories/DatasetSubjectPopulationRepositoryTest.php
+++ b/tests/Feature/Repositories/DatasetSubjectPopulationRepositoryTest.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace Tests\Feature\Repositories;
+
+use App\Enums\UserConsent\Jurisdiction;
+use App\Enums\UserConsent\SubjectRealm;
+use App\Models\Dataset;
+use App\Models\DatasetSnapshot;
+use App\Models\DatasetSubjectPopulation;
+use App\Repositories\DatasetSubjectPopulationRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DatasetSubjectPopulationRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private DatasetSubjectPopulationRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new DatasetSubjectPopulationRepository();
+    }
+
+    /**
+     * Test get paginated populations returns paginated results.
+     */
+    public function test_get_paginated_populations_returns_paginated_results(): void
+    {
+        DatasetSubjectPopulation::factory()->count(20)->create();
+
+        $result = $this->repository->getPaginatedPopulations(10);
+
+        $this->assertCount(10, $result->items());
+        $this->assertEquals(20, $result->total());
+        $this->assertEquals(2, $result->lastPage());
+    }
+
+    /**
+     * Test get paginated populations uses default per page value.
+     */
+    public function test_get_paginated_populations_uses_default_per_page(): void
+    {
+        DatasetSubjectPopulation::factory()->count(20)->create();
+
+        $result = $this->repository->getPaginatedPopulations();
+
+        $this->assertEquals(15, $result->perPage());
+    }
+
+    /**
+     * Test get paginated populations orders by as_of descending.
+     */
+    public function test_get_paginated_populations_orders_by_as_of_desc(): void
+    {
+        $oldPopulation = DatasetSubjectPopulation::factory()->create([
+            'as_of' => now()->subDays(10),
+        ]);
+        $newPopulation = DatasetSubjectPopulation::factory()->create([
+            'as_of' => now(),
+        ]);
+
+        $result = $this->repository->getPaginatedPopulations();
+
+        $this->assertEquals($newPopulation->id, $result->items()[0]->id);
+        $this->assertEquals($oldPopulation->id, $result->items()[1]->id);
+    }
+
+    /**
+     * Test get paginated populations eager loads relationships.
+     */
+    public function test_get_paginated_populations_eager_loads_relationships(): void
+    {
+        DatasetSubjectPopulation::factory()->create();
+
+        $result = $this->repository->getPaginatedPopulations();
+
+        $this->assertTrue($result->items()[0]->relationLoaded('dataset'));
+        $this->assertTrue($result->items()[0]->relationLoaded('snapshot'));
+    }
+
+    /**
+     * Test get paginated populations returns empty when no records.
+     */
+    public function test_get_paginated_populations_returns_empty_when_no_records(): void
+    {
+        $result = $this->repository->getPaginatedPopulations();
+
+        $this->assertCount(0, $result->items());
+        $this->assertEquals(0, $result->total());
+    }
+
+    /**
+     * Test create population creates new record with all fields.
+     */
+    public function test_create_population_creates_new_record_with_all_fields(): void
+    {
+        $dataset = Dataset::factory()->create();
+        $snapshot = DatasetSnapshot::factory()->for($dataset)->create();
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'snapshot_id' => $snapshot->id,
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+            'subjects_total' => 10000,
+            'as_of' => now(),
+        ];
+
+        $population = $this->repository->createPopulation($data);
+
+        $this->assertInstanceOf(DatasetSubjectPopulation::class, $population);
+        $this->assertEquals($data['dataset_id'], $population->dataset_id);
+        $this->assertEquals($data['snapshot_id'], $population->snapshot_id);
+        $this->assertEquals($data['subject_realm'], $population->subject_realm);
+        $this->assertEquals($data['jurisdiction'], $population->jurisdiction);
+        $this->assertEquals($data['subjects_total'], $population->subjects_total);
+        $this->assertNotNull($population->id);
+    }
+
+    /**
+     * Test create population without snapshot_id.
+     */
+    public function test_create_population_without_snapshot_id(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'subject_realm' => SubjectRealm::EMPLOYEE->value,
+            'jurisdiction' => Jurisdiction::US->value,
+            'subjects_total' => 5000,
+            'as_of' => now(),
+        ];
+
+        $population = $this->repository->createPopulation($data);
+
+        $this->assertNull($population->snapshot_id);
+        $this->assertEquals($data['dataset_id'], $population->dataset_id);
+    }
+
+    /**
+     * Test create population auto-sets created_at if not provided.
+     */
+    public function test_create_population_auto_sets_created_at(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+            'subjects_total' => 1000,
+            'as_of' => now(),
+        ];
+
+        $population = $this->repository->createPopulation($data);
+
+        $this->assertNotNull($population->created_at);
+    }
+
+    /**
+     * Test update population updates fields.
+     */
+    public function test_update_population_updates_fields(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create([
+            'subjects_total' => 1000,
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+        ]);
+
+        $updateData = [
+            'subjects_total' => 2000,
+            'subject_realm' => SubjectRealm::EMPLOYEE->value,
+        ];
+
+        $updated = $this->repository->updatePopulation($population, $updateData);
+
+        $this->assertEquals(2000, $updated->subjects_total);
+        $this->assertEquals(SubjectRealm::EMPLOYEE->value, $updated->subject_realm);
+    }
+
+    /**
+     * Test update population returns fresh instance.
+     */
+    public function test_update_population_returns_fresh_instance(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create([
+            'subjects_total' => 1000,
+        ]);
+
+        $updateData = [
+            'subjects_total' => 2000,
+        ];
+
+        $updated = $this->repository->updatePopulation($population, $updateData);
+
+        $this->assertNotSame($population, $updated);
+        $this->assertEquals(2000, $updated->subjects_total);
+    }
+
+    /**
+     * Test update population partial update.
+     */
+    public function test_update_population_partial_update(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create([
+            'subjects_total' => 1000,
+            'jurisdiction' => Jurisdiction::EU->value,
+        ]);
+
+        $updateData = [
+            'subjects_total' => 1500,
+        ];
+
+        $updated = $this->repository->updatePopulation($population, $updateData);
+
+        $this->assertEquals(1500, $updated->subjects_total);
+        $this->assertEquals(Jurisdiction::EU->value, $updated->jurisdiction);
+    }
+
+    /**
+     * Test delete population removes record.
+     */
+    public function test_delete_population_removes_record(): void
+    {
+        $population = DatasetSubjectPopulation::factory()->create();
+
+        $result = $this->repository->deletePopulation($population);
+
+        $this->assertTrue($result);
+        $this->assertDatabaseMissing('dataset_subject_populations', [
+            'id' => $population->id,
+        ]);
+    }
+
+    /**
+     * Test create population with all subject realms.
+     */
+    public function test_create_population_with_all_subject_realms(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $realms = [
+            SubjectRealm::CUSTOMER,
+            SubjectRealm::PROSPECT,
+            SubjectRealm::EMPLOYEE,
+            SubjectRealm::VENDOR,
+            SubjectRealm::OTHER,
+        ];
+
+        foreach ($realms as $realm) {
+            $data = [
+                'dataset_id' => $dataset->id,
+                'subject_realm' => $realm->value,
+                'jurisdiction' => Jurisdiction::EU->value,
+                'subjects_total' => 1000,
+                'as_of' => now(),
+            ];
+
+            $population = $this->repository->createPopulation($data);
+
+            $this->assertEquals($realm->value, $population->subject_realm);
+        }
+    }
+
+    /**
+     * Test create population with all jurisdictions.
+     */
+    public function test_create_population_with_all_jurisdictions(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $jurisdictions = [
+            Jurisdiction::AE,
+            Jurisdiction::EU,
+            Jurisdiction::KSA,
+            Jurisdiction::US,
+            Jurisdiction::UK,
+            Jurisdiction::QA,
+            Jurisdiction::JO,
+            Jurisdiction::MA,
+            Jurisdiction::BH,
+            Jurisdiction::OTHER,
+        ];
+
+        foreach ($jurisdictions as $jurisdiction) {
+            $data = [
+                'dataset_id' => $dataset->id,
+                'subject_realm' => SubjectRealm::CUSTOMER->value,
+                'jurisdiction' => $jurisdiction->value,
+                'subjects_total' => 1000,
+                'as_of' => now(),
+            ];
+
+            $population = $this->repository->createPopulation($data);
+
+            $this->assertEquals($jurisdiction->value, $population->jurisdiction);
+        }
+    }
+
+    /**
+     * Test create population with zero subjects.
+     */
+    public function test_create_population_with_zero_subjects(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+            'subjects_total' => 0,
+            'as_of' => now(),
+        ];
+
+        $population = $this->repository->createPopulation($data);
+
+        $this->assertEquals(0, $population->subjects_total);
+    }
+
+    /**
+     * Test create population with large subject numbers.
+     */
+    public function test_create_population_with_large_numbers(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+            'subjects_total' => 50000000,
+            'as_of' => now(),
+        ];
+
+        $population = $this->repository->createPopulation($data);
+
+        $this->assertEquals(50000000, $population->subjects_total);
+    }
+
+    /**
+     * Test create population with past as_of date.
+     */
+    public function test_create_population_with_past_as_of_date(): void
+    {
+        $dataset = Dataset::factory()->create();
+        $pastDate = now()->subMonths(6);
+
+        $data = [
+            'dataset_id' => $dataset->id,
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+            'jurisdiction' => Jurisdiction::EU->value,
+            'subjects_total' => 1000,
+            'as_of' => $pastDate,
+        ];
+
+        $population = $this->repository->createPopulation($data);
+
+        $this->assertEquals($pastDate->timestamp, $population->as_of->timestamp);
+    }
+}


### PR DESCRIPTION
- Implement DatasetSubjectPopulationController with CRUD operations.
- Create StoreDatasetSubjectPopulationRequest and UpdateDatasetSubjectPopulationRequest for validation.
- Develop DatasetSubjectPopulationResource for API responses.
- Create DatasetSubjectPopulation model and repository for data handling.
- Add DatasetSubjectPopulationFactory for test data generation.
- Implement migration for dataset_subject_populations table.
- Write comprehensive tests for DatasetSubjectPopulationController and Repository.