### PR TITLE
Add feature and unit tests for AiIncident management

### DIFF
--- a/app/Enums/ImpactedDataType.php
+++ b/app/Enums/ImpactedDataType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum ImpactedDataType: string
+{
+    case PII = 'pii';
+    case SENSITIVE_PERSONAL = 'sensitive_personal';
+    case FINANCIAL = 'financial';
+    case HEALTH = 'health';
+    case IP_COPYRIGHT = 'ip_copyright';
+    case NONE = 'none';
+    case UNKNOWN = 'unknown';
+}

--- a/app/Enums/IncidentCategory.php
+++ b/app/Enums/IncidentCategory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums;
+
+enum IncidentCategory: string
+{
+    case SAFETY = 'safety';
+    case PRIVACY = 'privacy';
+    case SECURITY = 'security';
+    case BIAS_FAIRNESS = 'bias_fairness';
+    case RELIABILITY = 'reliability';
+    case AVAILABILITY = 'availability';
+    case LEGAL_COMPLIANCE = 'legal_compliance';
+    case VENDOR = 'vendor';
+    case OTHER = 'other';
+}

--- a/app/Enums/IncidentSeverity.php
+++ b/app/Enums/IncidentSeverity.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum IncidentSeverity: string
+{
+    case SEV1_CRITICAL = 'sev1_critical';
+    case SEV2_HIGH = 'sev2_high';
+    case SEV3_MEDIUM = 'sev3_medium';
+    case SEV4_LOW = 'sev4_low';
+    case NEAR_MISS = 'near_miss';
+}

--- a/app/Enums/IncidentStage.php
+++ b/app/Enums/IncidentStage.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum IncidentStage: string
+{
+    case IDEATION = 'ideation';
+    case CONCEPTION = 'conception';
+    case DEV = 'dev';
+    case TEST = 'test';
+    case STAGING = 'staging';
+    case PROD = 'prod';
+    case RETIREMENT = 'retirement';
+}

--- a/app/Enums/IncidentStatus.php
+++ b/app/Enums/IncidentStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum IncidentStatus: string
+{
+    case OPEN = 'open';
+    case CONTAINED = 'contained';
+    case MONITORING = 'monitoring';
+    case RESOLVED = 'resolved';
+    case CLOSED = 'closed';
+}

--- a/app/Http/Controllers/User/AiIncidentController.php
+++ b/app/Http/Controllers/User/AiIncidentController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers\User;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\AiIncident\StoreAiIncidentRequest;
+use App\Http\Requests\AiIncident\UpdateAiIncidentRequest;
+use App\Http\Resources\AiIncidentResource;
+use App\Models\AiIncident;
+use App\Repositories\AiIncidentRepository;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class AiIncidentController extends Controller
+{
+    public function __construct(
+        private readonly AiIncidentRepository $repository
+    ) {}
+
+    /**
+     * Display a paginated listing of AI incidents.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = $request->input('per_page', 15);
+        $aiIncidents = $this->repository->getPaginatedAiIncidents($perPage);
+
+        return response()->json([
+            'error' => false,
+            'message' => 'AI incidents retrieved successfully',
+            'data' => $aiIncidents,
+        ]);
+    }
+
+    /**
+     * Store a newly created AI incident.
+     */
+    public function store(StoreAiIncidentRequest $request): JsonResponse
+    {
+        $aiIncident = $this->repository->createAiIncident($request->validated());
+
+        return response()->json([
+            'error' => false,
+            'message' => 'AI incident created successfully',
+            'data' => new AiIncidentResource($aiIncident),
+        ], 201);
+    }
+
+    /**
+     * Display the specified AI incident.
+     */
+    public function show(AiIncident $aiIncident): JsonResponse
+    {
+        return response()->json([
+            'error' => false,
+            'message' => 'AI incident retrieved successfully',
+            'data' => new AiIncidentResource($aiIncident),
+        ]);
+    }
+
+    /**
+     * Update the specified AI incident.
+     */
+    public function update(UpdateAiIncidentRequest $request, AiIncident $aiIncident): JsonResponse
+    {
+        $updated = $this->repository->updateAiIncident($aiIncident, $request->validated());
+
+        return response()->json([
+            'error' => false,
+            'message' => 'AI incident updated successfully',
+            'data' => new AiIncidentResource($updated),
+        ]);
+    }
+
+    /**
+     * Remove the specified AI incident.
+     */
+    public function destroy(AiIncident $aiIncident): JsonResponse
+    {
+        $this->repository->deleteAiIncident($aiIncident);
+
+        return response()->json([
+            'error' => false,
+            'message' => 'AI incident deleted successfully',
+        ]);
+    }
+}

--- a/app/Http/Requests/AiIncident/StoreAiIncidentRequest.php
+++ b/app/Http/Requests/AiIncident/StoreAiIncidentRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Requests\AiIncident;
+
+use App\Enums\IncidentCategory;
+use App\Enums\IncidentSeverity;
+use App\Enums\IncidentStage;
+use App\Enums\IncidentStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreAiIncidentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'summary' => ['required', 'string'],
+            'category' => ['required', 'string', Rule::enum(IncidentCategory::class)],
+            'severity' => ['required', 'string', Rule::enum(IncidentSeverity::class)],
+            'status' => ['required', 'string', Rule::enum(IncidentStatus::class)],
+            'stage' => ['required', 'string', Rule::enum(IncidentStage::class)],
+            'ic_owner' => ['required', 'string', 'max:255'],
+            'ai_model_id' => ['nullable', 'integer', 'exists:ai_models,id'],
+            'ai_model_version_id' => ['nullable', 'integer', 'exists:ai_model_versions,id'],
+            'use_case_id' => ['nullable', 'integer', 'exists:use_cases,id'],
+            'first_seen_at' => ['required', 'date'],
+            'declared_at' => ['required', 'date'],
+            'resolved_at' => ['nullable', 'date', 'after_or_equal:declared_at'],
+            'closed_at' => ['nullable', 'date', 'after_or_equal:resolved_at'],
+            'impacted_users' => ['nullable', 'string', 'max:255'],
+            'impacted_data' => ['required', 'array', 'min:1'],
+            'impacted_data.*' => ['required', 'string', 'in:pii,sensitive_personal,financial,health,ip_copyright,none,unknown'],
+            'impacted_systems' => ['nullable', 'string'],
+            'linked_release_id' => ['nullable', 'string', 'max:255'],
+            'linked_risk_id' => ['nullable', 'string', 'max:255'],
+            'linked_assessment_id' => ['nullable', 'string', 'max:255'],
+            'linked_capa_id' => ['nullable', 'string', 'max:255'],
+            'evidence_link' => ['nullable', 'url', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/AiIncident/UpdateAiIncidentRequest.php
+++ b/app/Http/Requests/AiIncident/UpdateAiIncidentRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Requests\AiIncident;
+
+use App\Enums\IncidentCategory;
+use App\Enums\IncidentSeverity;
+use App\Enums\IncidentStage;
+use App\Enums\IncidentStatus;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateAiIncidentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['sometimes', 'required', 'string', 'max:255'],
+            'summary' => ['sometimes', 'required', 'string'],
+            'category' => ['sometimes', 'required', 'string', Rule::enum(IncidentCategory::class)],
+            'severity' => ['sometimes', 'required', 'string', Rule::enum(IncidentSeverity::class)],
+            'status' => ['sometimes', 'required', 'string', Rule::enum(IncidentStatus::class)],
+            'stage' => ['sometimes', 'required', 'string', Rule::enum(IncidentStage::class)],
+            'ic_owner' => ['sometimes', 'required', 'string', 'max:255'],
+            'ai_model_id' => ['sometimes', 'nullable', 'integer', 'exists:ai_models,id'],
+            'ai_model_version_id' => ['sometimes', 'nullable', 'integer', 'exists:ai_model_versions,id'],
+            'use_case_id' => ['sometimes', 'nullable', 'integer', 'exists:use_cases,id'],
+            'first_seen_at' => ['sometimes', 'required', 'date'],
+            'declared_at' => ['sometimes', 'required', 'date'],
+            'resolved_at' => ['sometimes', 'nullable', 'date', 'after_or_equal:declared_at'],
+            'closed_at' => ['sometimes', 'nullable', 'date', 'after_or_equal:resolved_at'],
+            'impacted_users' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'impacted_data' => ['sometimes', 'required', 'array', 'min:1'],
+            'impacted_data.*' => ['required', 'string', 'in:pii,sensitive_personal,financial,health,ip_copyright,none,unknown'],
+            'impacted_systems' => ['sometimes', 'nullable', 'string'],
+            'linked_release_id' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'linked_risk_id' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'linked_assessment_id' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'linked_capa_id' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'evidence_link' => ['sometimes', 'nullable', 'url', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Resources/AiIncidentResource.php
+++ b/app/Http/Resources/AiIncidentResource.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\AiIncident;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin AiIncident
+ */
+class AiIncidentResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'summary' => $this->summary,
+            'category' => $this->category,
+            'severity' => $this->severity,
+            'status' => $this->status,
+            'stage' => $this->stage,
+            'ic_owner' => $this->ic_owner,
+            'ai_model_id' => $this->ai_model_id,
+            'ai_model_version_id' => $this->ai_model_version_id,
+            'use_case_id' => $this->use_case_id,
+            'first_seen_at' => $this->first_seen_at ? Carbon::parse($this->first_seen_at)->toIso8601String() : null,
+            'declared_at' => $this->declared_at ? Carbon::parse($this->declared_at)->toIso8601String() : null,
+            'resolved_at' => $this->resolved_at ? Carbon::parse($this->resolved_at)->toIso8601String() : null,
+            'closed_at' => $this->closed_at ? Carbon::parse($this->closed_at)->toIso8601String() : null,
+            'impacted_users' => $this->impacted_users,
+            'impacted_data' => $this->impacted_data,
+            'impacted_systems' => $this->impacted_systems,
+            'linked_release_id' => $this->linked_release_id,
+            'linked_risk_id' => $this->linked_risk_id,
+            'linked_assessment_id' => $this->linked_assessment_id,
+            'linked_capa_id' => $this->linked_capa_id,
+            'evidence_link' => $this->evidence_link,
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/AiIncident.php
+++ b/app/Models/AiIncident.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\AiIncidentFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AiIncident extends Model
+{
+    /** @use HasFactory<AiIncidentFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'summary',
+        'category',
+        'severity',
+        'status',
+        'stage',
+        'ic_owner',
+        'ai_model_id',
+        'ai_model_version_id',
+        'use_case_id',
+        'first_seen_at',
+        'declared_at',
+        'resolved_at',
+        'closed_at',
+        'impacted_users',
+        'impacted_data',
+        'impacted_systems',
+        'linked_release_id',
+        'linked_risk_id',
+        'linked_assessment_id',
+        'linked_capa_id',
+        'evidence_link',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'first_seen_at' => 'datetime',
+            'declared_at' => 'datetime',
+            'resolved_at' => 'datetime',
+            'closed_at' => 'datetime',
+            'impacted_data' => 'array',
+        ];
+    }
+}

--- a/app/Repositories/AiIncidentRepository.php
+++ b/app/Repositories/AiIncidentRepository.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\AiIncident;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+
+class AiIncidentRepository
+{
+    /**
+     * Get paginated AI incidents.
+     *
+     * @return LengthAwarePaginator<int, AiIncident>
+     */
+    public function getPaginatedAiIncidents(int $perPage = 15): LengthAwarePaginator
+    {
+        return AiIncident::query()
+            ->orderBy('created_at', 'desc')
+            ->paginate($perPage);
+    }
+
+    /**
+     * Create a new AI incident.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function createAiIncident(array $data): AiIncident
+    {
+        return AiIncident::create($data);
+    }
+
+    /**
+     * Update an existing AI incident.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function updateAiIncident(AiIncident $aiIncident, array $data): AiIncident
+    {
+        $aiIncident->update($data);
+        return $aiIncident->fresh();
+    }
+
+    /**
+     * Delete an AI incident.
+     */
+    public function deleteAiIncident(AiIncident $aiIncident): bool
+    {
+        return $aiIncident->delete();
+    }
+}

--- a/database/factories/AiIncidentFactory.php
+++ b/database/factories/AiIncidentFactory.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ImpactedDataType;
+use App\Enums\IncidentCategory;
+use App\Enums\IncidentSeverity;
+use App\Enums\IncidentStage;
+use App\Enums\IncidentStatus;
+use App\Models\AiIncident;
+use App\Models\AiModel;
+use App\Models\AiModelVersion;
+use App\Models\UseCase;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AiIncident>
+ */
+class AiIncidentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $firstSeenAt = $this->faker->dateTimeBetween('-30 days', '-1 day');
+        $declaredAt = $this->faker->dateTimeBetween($firstSeenAt, 'now');
+
+        $hasResolved = $this->faker->boolean(60);
+        $resolvedAt = $hasResolved ? $this->faker->dateTimeBetween($declaredAt, 'now') : null;
+
+        $hasClosed = $hasResolved && $this->faker->boolean(70);
+        $closedAt = $hasClosed ? $this->faker->dateTimeBetween($resolvedAt, 'now') : null;
+
+        // Select 1-3 impacted data types
+        $impactedDataTypes = $this->faker->randomElements(
+            array_map(fn($case) => $case->value, ImpactedDataType::cases()),
+            $this->faker->numberBetween(1, 3)
+        );
+
+        return [
+            'title' => $this->faker->sentence(6),
+            'summary' => $this->faker->paragraph(3),
+            'category' => $this->faker->randomElement(IncidentCategory::cases())->value,
+            'severity' => $this->faker->randomElement(IncidentSeverity::cases())->value,
+            'status' => $this->faker->randomElement(IncidentStatus::cases())->value,
+            'stage' => $this->faker->randomElement(IncidentStage::cases())->value,
+            'ic_owner' => $this->faker->name(),
+            'ai_model_id' => AiModel::factory(),
+            'ai_model_version_id' => AiModelVersion::factory(),
+            'use_case_id' => UseCase::factory(),
+            'first_seen_at' => $firstSeenAt,
+            'declared_at' => $declaredAt,
+            'resolved_at' => $resolvedAt,
+            'closed_at' => $closedAt,
+            'impacted_users' => $this->faker->boolean(70) ? $this->faker->randomElement([
+                'internal only',
+                '< 100 users',
+                '100-1000 users',
+                '1000+ users',
+                $this->faker->numberBetween(1, 10000) . ' users',
+            ]) : null,
+            'impacted_data' => $impactedDataTypes,
+            'impacted_systems' => $this->faker->boolean(60) ? $this->faker->sentence(10) : null,
+            'linked_release_id' => $this->faker->boolean(30) ? $this->faker->numberBetween(1, 100) : null,
+            'linked_risk_id' => $this->faker->boolean(40) ? $this->faker->numberBetween(1, 100) : null,
+            'linked_assessment_id' => $this->faker->boolean(30) ? $this->faker->numberBetween(1, 100) : null,
+            'linked_capa_id' => $this->faker->boolean(30) ? $this->faker->numberBetween(1, 100) : null,
+            'evidence_link' => $this->faker->boolean(50) ? $this->faker->url() : null,
+        ];
+    }
+
+    /**
+     * Indicate that the incident is critical.
+     */
+    public function critical(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'severity' => IncidentSeverity::SEV1_CRITICAL->value,
+            'status' => IncidentStatus::OPEN->value,
+        ]);
+    }
+
+    /**
+     * Indicate that the incident is resolved.
+     */
+    public function resolved(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'status' => IncidentStatus::RESOLVED->value,
+            'resolved_at' => now()->subDays($this->faker->numberBetween(1, 7)),
+        ]);
+    }
+
+    /**
+     * Indicate that the incident is closed.
+     */
+    public function closed(): static
+    {
+        $resolvedAt = now()->subDays($this->faker->numberBetween(7, 14));
+
+        return $this->state(fn(array $attributes) => [
+            'status' => IncidentStatus::CLOSED->value,
+            'resolved_at' => $resolvedAt,
+            'closed_at' => $this->faker->dateTimeBetween($resolvedAt, 'now'),
+        ]);
+    }
+
+    /**
+     * Indicate that the incident is in production.
+     */
+    public function production(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'stage' => IncidentStage::PROD->value,
+        ]);
+    }
+}

--- a/database/migrations/2025_10_29_100000_create_ai_incidents_table.php
+++ b/database/migrations/2025_10_29_100000_create_ai_incidents_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\AiModel;
+use App\Models\AiModelVersion;
+use App\Models\UseCase;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ai_incidents', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->text('summary');
+            $table->string('category');
+            $table->string('severity');
+            $table->string('status');
+            $table->string('stage');
+            $table->string('ic_owner');
+            $table->foreignIdFor(AiModel::class)->nullable()->constrained('ai_models')->nullOnDelete();
+            $table->foreignIdFor(AiModelVersion::class)->nullable()->constrained('ai_model_versions')->nullOnDelete();
+            $table->foreignIdFor(UseCase::class)->nullable()->constrained('use_cases')->nullOnDelete();
+            $table->dateTime('first_seen_at');
+            $table->dateTime('declared_at');
+            $table->dateTime('resolved_at')->nullable();
+            $table->dateTime('closed_at')->nullable();
+            $table->string('impacted_users')->nullable();
+            $table->json('impacted_data');
+            $table->text('impacted_systems')->nullable();
+            $table->string('linked_release_id')->nullable();
+            $table->string('linked_risk_id')->nullable();
+            $table->string('linked_assessment_id')->nullable();
+            $table->string('linked_capa_id')->nullable();
+            $table->string('evidence_link')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ai_incidents');
+    }
+};

--- a/routes/api/user.php
+++ b/routes/api/user.php
@@ -30,6 +30,7 @@ use App\Http\Controllers\User\PdpProcessingRegisterController;
 use App\Http\Controllers\User\VendorController;
 use App\Http\Controllers\User\AgreementController;
 use App\Http\Controllers\User\AiAssetController;
+use App\Http\Controllers\User\AiIncidentController;
 
 Route::middleware(['auth:supabase'])->group(function () {
     Route::prefix('/plans')->controller(BillingController::class)->group(function () {
@@ -214,5 +215,13 @@ Route::middleware(['auth:supabase'])->group(function () {
         Route::get('{aiAsset}', 'show');
         Route::post('{aiAsset}', 'update');
         Route::delete('{aiAsset}', 'destroy');
+    });
+
+    Route::prefix('ai-incidents')->controller(AiIncidentController::class)->group(function () {
+        Route::get('', 'index');
+        Route::post('', 'store');
+        Route::get('{aiIncident}', 'show');
+        Route::post('{aiIncident}', 'update');
+        Route::delete('{aiIncident}', 'destroy');
     });
 });

--- a/tests/Feature/AiIncidentControllerTest.php
+++ b/tests/Feature/AiIncidentControllerTest.php
@@ -1,0 +1,853 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\AiIncident;
+use App\Models\AiModel;
+use App\Models\AiModelVersion;
+use App\Models\User;
+use App\Models\UseCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AiIncidentControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    public function test_index_returns_paginated_ai_incidents(): void
+    {
+        AiIncident::factory()->count(15)->create();
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->getJson('/api/ai-incidents');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'error',
+                'message',
+                'data' => [
+                    'current_page',
+                    'data' => [
+                        '*' => [
+                            'id',
+                            'title',
+                            'summary',
+                            'category',
+                            'severity',
+                            'status',
+                            'stage',
+                            'ic_owner',
+                            'ai_model_id',
+                            'ai_model_version_id',
+                            'use_case_id',
+                            'first_seen_at',
+                            'declared_at',
+                            'resolved_at',
+                            'closed_at',
+                            'impacted_users',
+                            'impacted_data',
+                            'impacted_systems',
+                            'linked_release_id',
+                            'linked_risk_id',
+                            'linked_assessment_id',
+                            'linked_capa_id',
+                            'evidence_link',
+                            'created_at',
+                            'updated_at',
+                        ],
+                    ],
+                    'per_page',
+                    'total',
+                ]
+            ]);
+    }
+
+    public function test_index_returns_default_pagination(): void
+    {
+        AiIncident::factory()->count(20)->create();
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->getJson('/api/ai-incidents');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.per_page', 15);
+    }
+
+    public function test_index_accepts_custom_per_page(): void
+    {
+        AiIncident::factory()->count(20)->create();
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->getJson('/api/ai-incidents?per_page=5');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.per_page', 5)
+            ->assertJsonCount(5, 'data.data');
+    }
+
+    public function test_index_orders_by_created_at_desc(): void
+    {
+        $first = AiIncident::factory()->create([
+            'title' => 'First Incident',
+            'created_at' => now()->subDays(2),
+        ]);
+        $second = AiIncident::factory()->create([
+            'title' => 'Second Incident',
+            'created_at' => now()->subDay(),
+        ]);
+        $third = AiIncident::factory()->create([
+            'title' => 'Third Incident',
+            'created_at' => now(),
+        ]);
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->getJson('/api/ai-incidents');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.data.0.title', 'Third Incident')
+            ->assertJsonPath('data.data.1.title', 'Second Incident')
+            ->assertJsonPath('data.data.2.title', 'First Incident');
+    }
+
+    public function test_index_requires_authentication(): void
+    {
+        $response = $this->getJson('/api/ai-incidents');
+
+        $response->assertStatus(401);
+    }
+
+    public function test_store_creates_ai_incident_with_all_fields(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create();
+        $useCase = UseCase::factory()->create();
+
+        $data = [
+            'title' => 'Test Safety Incident',
+            'summary' => 'This is a detailed summary of the safety incident.',
+            'category' => 'safety',
+            'severity' => 'sev1_critical',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'use_case_id' => $useCase->id,
+            'first_seen_at' => now()->subHours(2)->toDateTimeString(),
+            'declared_at' => now()->subHour()->toDateTimeString(),
+            'impacted_users' => '1000+ users',
+            'impacted_data' => ['pii', 'financial'],
+            'impacted_systems' => 'Payment system, User database',
+            'linked_release_id' => 'REL-123',
+            'linked_risk_id' => 'RISK-456',
+            'evidence_link' => 'https://evidence.example.com/incident-123',
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(201)
+            ->assertJson([
+                'error' => false,
+                'message' => 'AI incident created successfully',
+            ])
+            ->assertJsonPath('data.title', 'Test Safety Incident')
+            ->assertJsonPath('data.category', 'safety')
+            ->assertJsonPath('data.severity', 'sev1_critical')
+            ->assertJsonPath('data.status', 'open')
+            ->assertJsonPath('data.stage', 'prod')
+            ->assertJsonPath('data.ic_owner', 'John Doe')
+            ->assertJsonPath('data.ai_model_id', $aiModel->id)
+            ->assertJsonPath('data.ai_model_version_id', $aiModelVersion->id)
+            ->assertJsonPath('data.use_case_id', $useCase->id)
+            ->assertJsonPath('data.impacted_users', '1000+ users')
+            ->assertJsonPath('data.linked_release_id', 'REL-123')
+            ->assertJsonPath('data.evidence_link', 'https://evidence.example.com/incident-123');
+
+        $this->assertDatabaseHas('ai_incidents', [
+            'title' => 'Test Safety Incident',
+            'category' => 'safety',
+            'severity' => 'sev1_critical',
+            'ai_model_id' => $aiModel->id,
+        ]);
+    }
+
+    public function test_store_validates_title_is_required(): void
+    {
+        $data = [
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['title']);
+    }
+
+    public function test_store_validates_summary_is_required(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'category' => 'safety',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['summary']);
+    }
+
+    public function test_store_validates_first_seen_at_is_required(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['first_seen_at']);
+    }
+
+    public function test_store_validates_declared_at_is_required(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['declared_at']);
+    }
+
+    public function test_store_validates_impacted_data_is_required(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['impacted_data']);
+    }
+
+    public function test_store_validates_impacted_data_requires_at_least_one(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => [],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['impacted_data']);
+    }
+
+    public function test_store_validates_impacted_data_values(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['invalid_value'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['impacted_data.0']);
+    }
+
+    public function test_store_validates_category_is_required(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['category']);
+    }
+
+    public function test_store_validates_category_enum(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'invalid_category',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['category']);
+    }
+
+    public function test_store_validates_severity_is_required(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['severity']);
+    }
+
+    public function test_store_validates_severity_enum(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'severity' => 'invalid_severity',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['severity']);
+    }
+
+    public function test_store_validates_status_is_required(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'severity' => 'sev2_high',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['status']);
+    }
+
+    public function test_store_validates_status_enum(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'severity' => 'sev2_high',
+            'status' => 'invalid_status',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['status']);
+    }
+
+    public function test_store_validates_stage_is_required(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['stage']);
+    }
+
+    public function test_store_validates_stage_enum(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'stage' => 'invalid_stage',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['stage']);
+    }
+
+    public function test_store_validates_ic_owner_is_required(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'Test summary',
+            'category' => 'safety',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'stage' => 'prod',
+            'first_seen_at' => now()->subHour()->toDateTimeString(),
+            'declared_at' => now()->toDateTimeString(),
+            'impacted_data' => ['pii'],
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/ai-incidents', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['ic_owner']);
+    }
+
+    public function test_store_requires_authentication(): void
+    {
+        $response = $this->postJson('/api/ai-incidents', []);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_show_returns_ai_incident(): void
+    {
+        $aiIncident = AiIncident::factory()->create([
+            'title' => 'Test Incident',
+            'category' => 'privacy',
+        ]);
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->getJson("/api/ai-incidents/{$aiIncident->id}");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'error' => false,
+                'message' => 'AI incident retrieved successfully',
+            ])
+            ->assertJsonPath('data.id', $aiIncident->id)
+            ->assertJsonPath('data.title', 'Test Incident')
+            ->assertJsonPath('data.category', 'privacy');
+    }
+
+    public function test_show_returns_404_for_non_existent_ai_incident(): void
+    {
+        $response = $this->actingAs($this->user, 'supabase')
+            ->getJson('/api/ai-incidents/99999');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_show_requires_authentication(): void
+    {
+        $aiIncident = AiIncident::factory()->create();
+
+        $response = $this->getJson("/api/ai-incidents/{$aiIncident->id}");
+
+        $response->assertStatus(401);
+    }
+
+    public function test_update_modifies_ai_incident(): void
+    {
+        $aiIncident = AiIncident::factory()->create([
+            'title' => 'Original Title',
+            'status' => 'open',
+        ]);
+
+        $updateData = [
+            'title' => 'Updated Title',
+            'status' => 'resolved',
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson("/api/ai-incidents/{$aiIncident->id}", $updateData);
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'error' => false,
+                'message' => 'AI incident updated successfully',
+            ])
+            ->assertJsonPath('data.title', 'Updated Title')
+            ->assertJsonPath('data.status', 'resolved');
+
+        $this->assertDatabaseHas('ai_incidents', [
+            'id' => $aiIncident->id,
+            'title' => 'Updated Title',
+            'status' => 'resolved',
+        ]);
+    }
+
+    public function test_update_supports_partial_updates(): void
+    {
+        $aiIncident = AiIncident::factory()->create([
+            'title' => 'Test Incident',
+            'category' => 'security',
+            'severity' => 'sev3_medium',
+        ]);
+
+        $updateData = ['severity' => 'sev1_critical'];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson("/api/ai-incidents/{$aiIncident->id}", $updateData);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.title', 'Test Incident')
+            ->assertJsonPath('data.category', 'security')
+            ->assertJsonPath('data.severity', 'sev1_critical');
+    }
+
+    public function test_update_can_change_status(): void
+    {
+        $aiIncident = AiIncident::factory()->create(['status' => 'open']);
+
+        $updateData = ['status' => 'closed'];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson("/api/ai-incidents/{$aiIncident->id}", $updateData);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.status', 'closed');
+
+        $this->assertDatabaseHas('ai_incidents', [
+            'id' => $aiIncident->id,
+            'status' => 'closed',
+        ]);
+    }
+
+    public function test_update_can_change_ic_owner(): void
+    {
+        $aiIncident = AiIncident::factory()->create(['ic_owner' => 'John Doe']);
+
+        $updateData = ['ic_owner' => 'Jane Smith'];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson("/api/ai-incidents/{$aiIncident->id}", $updateData);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.ic_owner', 'Jane Smith');
+
+        $this->assertDatabaseHas('ai_incidents', [
+            'id' => $aiIncident->id,
+            'ic_owner' => 'Jane Smith',
+        ]);
+    }
+
+    public function test_update_validates_category_enum(): void
+    {
+        $aiIncident = AiIncident::factory()->create();
+
+        $updateData = ['category' => 'invalid_category'];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson("/api/ai-incidents/{$aiIncident->id}", $updateData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['category']);
+    }
+
+    public function test_update_validates_severity_enum(): void
+    {
+        $aiIncident = AiIncident::factory()->create();
+
+        $updateData = ['severity' => 'invalid_severity'];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson("/api/ai-incidents/{$aiIncident->id}", $updateData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['severity']);
+    }
+
+    public function test_update_validates_status_enum(): void
+    {
+        $aiIncident = AiIncident::factory()->create();
+
+        $updateData = ['status' => 'invalid_status'];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson("/api/ai-incidents/{$aiIncident->id}", $updateData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['status']);
+    }
+
+    public function test_update_validates_stage_enum(): void
+    {
+        $aiIncident = AiIncident::factory()->create();
+
+        $updateData = ['stage' => 'invalid_stage'];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson("/api/ai-incidents/{$aiIncident->id}", $updateData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['stage']);
+    }
+
+    public function test_update_requires_authentication(): void
+    {
+        $aiIncident = AiIncident::factory()->create();
+
+        $response = $this->postJson("/api/ai-incidents/{$aiIncident->id}", []);
+
+        $response->assertStatus(401);
+    }
+
+    public function test_destroy_deletes_ai_incident(): void
+    {
+        $aiIncident = AiIncident::factory()->create();
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->deleteJson("/api/ai-incidents/{$aiIncident->id}");
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'error' => false,
+                'message' => 'AI incident deleted successfully',
+            ]);
+
+        $this->assertDatabaseMissing('ai_incidents', [
+            'id' => $aiIncident->id,
+        ]);
+    }
+
+    public function test_destroy_returns_404_for_non_existent_ai_incident(): void
+    {
+        $response = $this->actingAs($this->user, 'supabase')
+            ->deleteJson('/api/ai-incidents/99999');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_destroy_requires_authentication(): void
+    {
+        $aiIncident = AiIncident::factory()->create();
+
+        $response = $this->deleteJson("/api/ai-incidents/{$aiIncident->id}");
+
+        $response->assertStatus(401);
+    }
+
+    public function test_store_accepts_all_valid_categories(): void
+    {
+        $categories = ['safety', 'privacy', 'security', 'bias_fairness', 'reliability', 'availability', 'legal_compliance', 'vendor', 'other'];
+
+        foreach ($categories as $category) {
+            $data = [
+                'title' => "Test {$category} Incident",
+                'summary' => 'Test summary',
+                'category' => $category,
+                'severity' => 'sev2_high',
+                'status' => 'open',
+                'stage' => 'prod',
+                'ic_owner' => 'Test Owner',
+                'first_seen_at' => now()->subHour()->toDateTimeString(),
+                'declared_at' => now()->toDateTimeString(),
+                'impacted_data' => ['pii'],
+            ];
+
+            $response = $this->actingAs($this->user, 'supabase')
+                ->postJson('/api/ai-incidents', $data);
+
+            $response->assertStatus(201)
+                ->assertJsonPath('data.category', $category);
+        }
+    }
+
+    public function test_store_accepts_all_valid_severities(): void
+    {
+        $severities = ['sev1_critical', 'sev2_high', 'sev3_medium', 'sev4_low', 'near_miss'];
+
+        foreach ($severities as $severity) {
+            $data = [
+                'title' => "Test {$severity} Incident",
+                'summary' => 'Test summary',
+                'category' => 'safety',
+                'severity' => $severity,
+                'status' => 'open',
+                'stage' => 'prod',
+                'ic_owner' => 'Test Owner',
+                'first_seen_at' => now()->subHour()->toDateTimeString(),
+                'declared_at' => now()->toDateTimeString(),
+                'impacted_data' => ['pii'],
+            ];
+
+            $response = $this->actingAs($this->user, 'supabase')
+                ->postJson('/api/ai-incidents', $data);
+
+            $response->assertStatus(201)
+                ->assertJsonPath('data.severity', $severity);
+        }
+    }
+
+    public function test_store_accepts_all_valid_statuses(): void
+    {
+        $statuses = ['open', 'contained', 'monitoring', 'resolved', 'closed'];
+
+        foreach ($statuses as $status) {
+            $data = [
+                'title' => "Test {$status} Incident",
+                'summary' => 'Test summary',
+                'category' => 'safety',
+                'severity' => 'sev2_high',
+                'status' => $status,
+                'stage' => 'prod',
+                'ic_owner' => 'Test Owner',
+                'first_seen_at' => now()->subHour()->toDateTimeString(),
+                'declared_at' => now()->toDateTimeString(),
+                'impacted_data' => ['pii'],
+            ];
+
+            $response = $this->actingAs($this->user, 'supabase')
+                ->postJson('/api/ai-incidents', $data);
+
+            $response->assertStatus(201)
+                ->assertJsonPath('data.status', $status);
+        }
+    }
+
+    public function test_store_accepts_all_valid_stages(): void
+    {
+        $stages = ['ideation', 'conception', 'dev', 'test', 'staging', 'prod', 'retirement'];
+
+        foreach ($stages as $stage) {
+            $data = [
+                'title' => "Test {$stage} Incident",
+                'summary' => 'Test summary',
+                'category' => 'safety',
+                'severity' => 'sev2_high',
+                'status' => 'open',
+                'stage' => $stage,
+                'ic_owner' => 'Test Owner',
+                'first_seen_at' => now()->subHour()->toDateTimeString(),
+                'declared_at' => now()->toDateTimeString(),
+                'impacted_data' => ['pii'],
+            ];
+
+            $response = $this->actingAs($this->user, 'supabase')
+                ->postJson('/api/ai-incidents', $data);
+
+            $response->assertStatus(201)
+                ->assertJsonPath('data.stage', $stage);
+        }
+    }
+}

--- a/tests/Unit/AiIncidentRepositoryTest.php
+++ b/tests/Unit/AiIncidentRepositoryTest.php
@@ -1,0 +1,403 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\AiIncident;
+use App\Models\AiModel;
+use App\Models\AiModelVersion;
+use App\Models\UseCase;
+use App\Repositories\AiIncidentRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AiIncidentRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private AiIncidentRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = new AiIncidentRepository();
+    }
+
+    public function test_get_paginated_ai_incidents_returns_paginated_collection(): void
+    {
+        AiIncident::factory()->count(15)->create();
+
+        $result = $this->repository->getPaginatedAiIncidents(10);
+
+        $this->assertCount(10, $result->items());
+        $this->assertEquals(15, $result->total());
+    }
+
+    public function test_get_paginated_ai_incidents_with_custom_per_page(): void
+    {
+        AiIncident::factory()->count(20)->create();
+
+        $result = $this->repository->getPaginatedAiIncidents(5);
+
+        $this->assertCount(5, $result->items());
+        $this->assertEquals(20, $result->total());
+    }
+
+    public function test_get_paginated_ai_incidents_orders_by_created_at_desc(): void
+    {
+        $first = AiIncident::factory()->create(['created_at' => now()->subDays(2)]);
+        $second = AiIncident::factory()->create(['created_at' => now()->subDay()]);
+        $third = AiIncident::factory()->create(['created_at' => now()]);
+
+        $result = $this->repository->getPaginatedAiIncidents(10);
+
+        $this->assertEquals($third->id, $result->items()[0]->id);
+        $this->assertEquals($second->id, $result->items()[1]->id);
+        $this->assertEquals($first->id, $result->items()[2]->id);
+    }
+
+    public function test_create_ai_incident_creates_new_record(): void
+    {
+        $data = [
+            'title' => 'Test Incident',
+            'summary' => 'This is a test incident summary.',
+            'category' => 'safety',
+            'severity' => 'sev1_critical',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'John Doe',
+            'first_seen_at' => now()->subHours(2),
+            'declared_at' => now()->subHour(),
+            'impacted_data' => ['pii', 'sensitive_personal'],
+        ];
+
+        $aiIncident = $this->repository->createAiIncident($data);
+
+        $this->assertInstanceOf(AiIncident::class, $aiIncident);
+        $this->assertEquals('Test Incident', $aiIncident->title);
+        $this->assertEquals('safety', $aiIncident->category);
+        $this->assertIsArray($aiIncident->impacted_data);
+        $this->assertDatabaseHas('ai_incidents', [
+            'id' => $aiIncident->id,
+            'title' => 'Test Incident',
+            'category' => 'safety',
+            'severity' => 'sev1_critical',
+        ]);
+    }
+
+    public function test_create_ai_incident_with_all_fields(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create();
+        $useCase = UseCase::factory()->create();
+
+        $data = [
+            'title' => 'Privacy Breach',
+            'summary' => 'User data was exposed due to misconfiguration.',
+            'category' => 'privacy',
+            'severity' => 'sev2_high',
+            'status' => 'contained',
+            'stage' => 'staging',
+            'ic_owner' => 'Jane Smith',
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'use_case_id' => $useCase->id,
+            'first_seen_at' => now()->subDays(2),
+            'declared_at' => now()->subDay(),
+            'resolved_at' => now()->subHours(6),
+            'closed_at' => now()->subHours(2),
+            'impacted_users' => '1000+ users',
+            'impacted_data' => ['pii', 'financial'],
+            'impacted_systems' => 'Payment processing, User authentication',
+            'linked_release_id' => 'REL-123',
+            'linked_risk_id' => 'RISK-456',
+            'linked_assessment_id' => 'ASS-789',
+            'linked_capa_id' => 'CAPA-101',
+            'evidence_link' => 'https://evidence.example.com/incident-123',
+        ];
+
+        $aiIncident = $this->repository->createAiIncident($data);
+
+        $this->assertEquals('Privacy Breach', $aiIncident->title);
+        $this->assertEquals('privacy', $aiIncident->category);
+        $this->assertEquals($aiModel->id, $aiIncident->ai_model_id);
+        $this->assertEquals($aiModelVersion->id, $aiIncident->ai_model_version_id);
+        $this->assertEquals($useCase->id, $aiIncident->use_case_id);
+        $this->assertEquals('1000+ users', $aiIncident->impacted_users);
+        $this->assertIsArray($aiIncident->impacted_data);
+        $this->assertContains('pii', $aiIncident->impacted_data);
+        $this->assertContains('financial', $aiIncident->impacted_data);
+        $this->assertEquals('https://evidence.example.com/incident-123', $aiIncident->evidence_link);
+        $this->assertDatabaseHas('ai_incidents', [
+            'id' => $aiIncident->id,
+            'ic_owner' => 'Jane Smith',
+            'linked_release_id' => 'REL-123',
+        ]);
+    }
+
+    public function test_update_ai_incident_updates_existing_record(): void
+    {
+        $aiIncident = AiIncident::factory()->create([
+            'title' => 'Original Title',
+            'status' => 'open',
+            'resolved_at' => null,
+        ]);
+
+        $updateData = [
+            'title' => 'Updated Title',
+            'status' => 'resolved',
+            'resolved_at' => now(),
+        ];
+
+        $updated = $this->repository->updateAiIncident($aiIncident, $updateData);
+
+        $this->assertInstanceOf(AiIncident::class, $updated);
+        $this->assertEquals('Updated Title', $updated->title);
+        $this->assertEquals('resolved', $updated->status);
+        $this->assertNotNull($updated->resolved_at);
+        $this->assertDatabaseHas('ai_incidents', [
+            'id' => $aiIncident->id,
+            'title' => 'Updated Title',
+            'status' => 'resolved',
+        ]);
+    }
+
+    public function test_update_ai_incident_partial_update(): void
+    {
+        $aiIncident = AiIncident::factory()->create([
+            'title' => 'Test Incident',
+            'category' => 'security',
+            'severity' => 'sev3_medium',
+        ]);
+
+        $updateData = ['severity' => 'sev1_critical'];
+
+        $updated = $this->repository->updateAiIncident($aiIncident, $updateData);
+
+        $this->assertEquals('Test Incident', $updated->title);
+        $this->assertEquals('security', $updated->category);
+        $this->assertEquals('sev1_critical', $updated->severity);
+    }
+
+    public function test_update_ai_incident_can_change_status(): void
+    {
+        $aiIncident = AiIncident::factory()->create(['status' => 'open']);
+
+        $updateData = ['status' => 'closed'];
+
+        $updated = $this->repository->updateAiIncident($aiIncident, $updateData);
+
+        $this->assertEquals('closed', $updated->status);
+        $this->assertDatabaseHas('ai_incidents', [
+            'id' => $aiIncident->id,
+            'status' => 'closed',
+        ]);
+    }
+
+    public function test_update_ai_incident_can_change_ic_owner(): void
+    {
+        $aiIncident = AiIncident::factory()->create(['ic_owner' => 'John Doe']);
+
+        $updateData = ['ic_owner' => 'Jane Smith'];
+
+        $updated = $this->repository->updateAiIncident($aiIncident, $updateData);
+
+        $this->assertEquals('Jane Smith', $updated->ic_owner);
+        $this->assertDatabaseHas('ai_incidents', [
+            'id' => $aiIncident->id,
+            'ic_owner' => 'Jane Smith',
+        ]);
+    }
+
+    public function test_delete_ai_incident_removes_record(): void
+    {
+        $aiIncident = AiIncident::factory()->create();
+
+        $result = $this->repository->deleteAiIncident($aiIncident);
+
+        $this->assertTrue($result);
+        $this->assertDatabaseMissing('ai_incidents', [
+            'id' => $aiIncident->id,
+        ]);
+    }
+
+    public function test_delete_ai_incident_returns_true_on_success(): void
+    {
+        $aiIncident = AiIncident::factory()->create();
+
+        $result = $this->repository->deleteAiIncident($aiIncident);
+
+        $this->assertTrue($result);
+    }
+
+    public function test_get_paginated_ai_incidents_handles_empty_results(): void
+    {
+        $result = $this->repository->getPaginatedAiIncidents(10);
+
+        $this->assertCount(0, $result->items());
+        $this->assertEquals(0, $result->total());
+    }
+
+    public function test_update_ai_incident_can_update_all_fields(): void
+    {
+        $aiIncident = AiIncident::factory()->create();
+        $newAiModel = AiModel::factory()->create();
+
+        $updateData = [
+            'title' => 'Completely Updated Title',
+            'summary' => 'Completely updated summary.',
+            'category' => 'vendor',
+            'severity' => 'near_miss',
+            'status' => 'closed',
+            'stage' => 'retirement',
+            'ic_owner' => 'New Owner',
+            'ai_model_id' => $newAiModel->id,
+            'impacted_users' => 'internal only',
+            'impacted_data' => ['none'],
+            'impacted_systems' => 'Legacy system',
+            'evidence_link' => 'https://new-evidence.example.com',
+        ];
+
+        $updated = $this->repository->updateAiIncident($aiIncident, $updateData);
+
+        $this->assertEquals('Completely Updated Title', $updated->title);
+        $this->assertEquals('Completely updated summary.', $updated->summary);
+        $this->assertEquals('vendor', $updated->category);
+        $this->assertEquals('near_miss', $updated->severity);
+        $this->assertEquals('closed', $updated->status);
+        $this->assertEquals('retirement', $updated->stage);
+        $this->assertEquals('New Owner', $updated->ic_owner);
+        $this->assertEquals($newAiModel->id, $updated->ai_model_id);
+        $this->assertEquals('internal only', $updated->impacted_users);
+        $this->assertEquals(['none'], $updated->impacted_data);
+        $this->assertEquals('Legacy system', $updated->impacted_systems);
+        $this->assertEquals('https://new-evidence.example.com', $updated->evidence_link);
+    }
+
+    public function test_create_ai_incident_with_model_relationships(): void
+    {
+        $aiModel = AiModel::factory()->create();
+        $aiModelVersion = AiModelVersion::factory()->create();
+        $useCase = UseCase::factory()->create();
+
+        $data = [
+            'title' => 'Model-Related Incident',
+            'summary' => 'Incident involving specific model',
+            'category' => 'reliability',
+            'severity' => 'sev3_medium',
+            'status' => 'monitoring',
+            'stage' => 'prod',
+            'ic_owner' => 'Test Owner',
+            'ai_model_id' => $aiModel->id,
+            'ai_model_version_id' => $aiModelVersion->id,
+            'use_case_id' => $useCase->id,
+            'first_seen_at' => now()->subHour(),
+            'declared_at' => now(),
+            'impacted_data' => ['unknown'],
+        ];
+
+        $aiIncident = $this->repository->createAiIncident($data);
+
+        $this->assertEquals($aiModel->id, $aiIncident->ai_model_id);
+        $this->assertEquals($aiModelVersion->id, $aiIncident->ai_model_version_id);
+        $this->assertEquals($useCase->id, $aiIncident->use_case_id);
+    }
+
+    public function test_create_ai_incident_with_impacted_data_array(): void
+    {
+        $data = [
+            'title' => 'Data Impact Test',
+            'summary' => 'Testing multiple data types',
+            'category' => 'privacy',
+            'severity' => 'sev2_high',
+            'status' => 'open',
+            'stage' => 'prod',
+            'ic_owner' => 'Data Officer',
+            'first_seen_at' => now()->subHour(),
+            'declared_at' => now(),
+            'impacted_data' => ['pii', 'financial', 'health'],
+        ];
+
+        $aiIncident = $this->repository->createAiIncident($data);
+
+        $this->assertIsArray($aiIncident->impacted_data);
+        $this->assertCount(3, $aiIncident->impacted_data);
+        $this->assertContains('pii', $aiIncident->impacted_data);
+        $this->assertContains('financial', $aiIncident->impacted_data);
+        $this->assertContains('health', $aiIncident->impacted_data);
+    }
+
+    public function test_update_ai_incident_can_update_impacted_data(): void
+    {
+        $aiIncident = AiIncident::factory()->create([
+            'impacted_data' => ['pii'],
+        ]);
+
+        $updateData = [
+            'impacted_data' => ['pii', 'financial', 'sensitive_personal'],
+        ];
+
+        $updated = $this->repository->updateAiIncident($aiIncident, $updateData);
+
+        $this->assertCount(3, $updated->impacted_data);
+        $this->assertContains('pii', $updated->impacted_data);
+        $this->assertContains('financial', $updated->impacted_data);
+        $this->assertContains('sensitive_personal', $updated->impacted_data);
+    }
+
+    public function test_create_ai_incident_with_datetime_fields(): void
+    {
+        $firstSeen = now()->subDays(3);
+        $declared = now()->subDays(2);
+        $resolved = now()->subDay();
+        $closed = now();
+
+        $data = [
+            'title' => 'Datetime Test',
+            'summary' => 'Testing datetime fields',
+            'category' => 'security',
+            'severity' => 'sev1_critical',
+            'status' => 'closed',
+            'stage' => 'prod',
+            'ic_owner' => 'Security Lead',
+            'first_seen_at' => $firstSeen,
+            'declared_at' => $declared,
+            'resolved_at' => $resolved,
+            'closed_at' => $closed,
+            'impacted_data' => ['pii'],
+        ];
+
+        $aiIncident = $this->repository->createAiIncident($data);
+
+        $this->assertEquals($firstSeen->toDateTimeString(), $aiIncident->first_seen_at->toDateTimeString());
+        $this->assertEquals($declared->toDateTimeString(), $aiIncident->declared_at->toDateTimeString());
+        $this->assertEquals($resolved->toDateTimeString(), $aiIncident->resolved_at->toDateTimeString());
+        $this->assertEquals($closed->toDateTimeString(), $aiIncident->closed_at->toDateTimeString());
+    }
+
+    public function test_create_ai_incident_with_linked_ids(): void
+    {
+        $data = [
+            'title' => 'Linked Records Test',
+            'summary' => 'Testing linked IDs',
+            'category' => 'other',
+            'severity' => 'sev4_low',
+            'status' => 'open',
+            'stage' => 'test',
+            'ic_owner' => 'Test Manager',
+            'first_seen_at' => now()->subHour(),
+            'declared_at' => now(),
+            'impacted_data' => ['none'],
+            'linked_release_id' => 'REL-999',
+            'linked_risk_id' => 'RISK-888',
+            'linked_assessment_id' => 'ASS-777',
+            'linked_capa_id' => 'CAPA-666',
+        ];
+
+        $aiIncident = $this->repository->createAiIncident($data);
+
+        $this->assertEquals('REL-999', $aiIncident->linked_release_id);
+        $this->assertEquals('RISK-888', $aiIncident->linked_risk_id);
+        $this->assertEquals('ASS-777', $aiIncident->linked_assessment_id);
+        $this->assertEquals('CAPA-666', $aiIncident->linked_capa_id);
+    }
+}


### PR DESCRIPTION
- Implement AiIncidentControllerTest to cover index, store, show, update, and destroy functionalities with various assertions.
- Validate authentication and input requirements for creating and updating AI incidents.
- Ensure pagination and ordering of AI incidents in the index method.
- Create AiIncidentRepositoryTest to validate repository methods for pagination, creation, updating, and deletion of AI incidents.
- Test handling of impacted data and linked IDs in AI incidents.