### PR TITLE
Refactor tests to include organization_id in various repository tests

### DIFF
--- a/app/Http/Controllers/User/AiModelCardController.php
+++ b/app/Http/Controllers/User/AiModelCardController.php
@@ -10,6 +10,7 @@ use App\Http\Resources\AiModelCardResource;
 use App\Models\AiModelCard;
 use App\Repositories\AiModelCardRepository;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
 
 class AiModelCardController extends Controller
 {
@@ -17,8 +18,9 @@ class AiModelCardController extends Controller
 
     public function index(ListAiModelCardRequest $request): JsonResponse
     {
+        $organizationID = Auth::user()->organization_id;
         $perPage = $request->input('per_page') ?? 15;
-        $aiModelCards = $this->aiModelCardRepository->getPaginatedAiModelCards($perPage);
+        $aiModelCards = $this->aiModelCardRepository->getPaginatedAiModelCardsByOrganizationID($organizationID, $perPage);
         return response()->json([
             'error' => false,
             'data' => $aiModelCards,
@@ -28,6 +30,7 @@ class AiModelCardController extends Controller
     public function store(StoreAiModelCardRequest $request): JsonResponse
     {
         $data = $request->validated();
+        $data['organization_id'] = $request->user()->organization_id;
         $this->aiModelCardRepository->createAiModelCard($data);
 
         return response()->json([

--- a/app/Http/Controllers/User/AiModelDatasetController.php
+++ b/app/Http/Controllers/User/AiModelDatasetController.php
@@ -10,6 +10,7 @@ use App\Models\AiModelDataset;
 use App\Repositories\AiModelDatasetRepository;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class AiModelDatasetController extends Controller
 {
@@ -18,8 +19,9 @@ class AiModelDatasetController extends Controller
 
     public function index(Request $request): JsonResponse
     {
+        $organizationId = Auth::user()->organization_id;
         $perPage = $request->input('per_page') ?? 15;
-        $aiModelDatasets = $this->aiModelDatasetRepository->getPaginatedAiModelDatasets($perPage);
+        $aiModelDatasets = $this->aiModelDatasetRepository->getPaginatedAiModelDatasets($organizationId, $perPage);
 
         return response()->json([
             'error' => false,
@@ -30,6 +32,7 @@ class AiModelDatasetController extends Controller
     public function store(StoreAiModelDatasetRequest $request): JsonResponse
     {
         $validated = $request->validated();
+        $validated['organization_id'] = $request->user()->organization_id;
 
         $aiModelDataset = $this->aiModelDatasetRepository->create($validated);
 

--- a/app/Http/Controllers/User/AiModelUseCaseController.php
+++ b/app/Http/Controllers/User/AiModelUseCaseController.php
@@ -18,7 +18,9 @@ class AiModelUseCaseController extends Controller
 
     public function index(SearchAiModelUseCaseRequest $request): JsonResponse
     {
-        $aiModelUseCases = $this->aiModelUseCaseRepository->getFilteredAiModelUseCases($request->validated());
+        $filters = $request->validated();
+        $filters['organization_id'] = Auth::user()->organization_id;
+        $aiModelUseCases = $this->aiModelUseCaseRepository->getFilteredAiModelUseCases($filters);
         return response()->json([
             'error' => false,
             'message' => 'AI Model Use Case associations retrieved successfully',
@@ -30,6 +32,7 @@ class AiModelUseCaseController extends Controller
     {
         $user = Auth::user();
         $validated = $request->validated();
+        $validated['organization_id'] = $user->organization_id;
         $this->aiModelUseCaseRepository->createAiModelUseCase($user, $validated);
         return response()->json([
             'error' => false,

--- a/app/Http/Controllers/User/AiModelVersionController.php
+++ b/app/Http/Controllers/User/AiModelVersionController.php
@@ -10,6 +10,7 @@ use App\Models\AiModelVersion;
 use App\Repositories\AiModelVersionRepository;
 use App\Http\Requests\ListAiModelVersionRequest;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
 
 class AiModelVersionController extends Controller
 {
@@ -18,6 +19,7 @@ class AiModelVersionController extends Controller
     public function index(ListAiModelVersionRequest $request): JsonResponse
     {
         $validated = $request->validated();
+        $validated['organization_id'] = Auth::user()->organization_id;
         $aiModelVersions = $this->aiModelVersionRepository->getFilteredAiModelVersions($validated);
 
         return response()->json([
@@ -30,6 +32,7 @@ class AiModelVersionController extends Controller
     public function store(StoreAiModelVersionRequest $request): JsonResponse
     {
         $validated = $request->validated();
+        $validated['organization_id'] = $request->user()->organization_id;
 
         $this->aiModelVersionRepository->create($validated);
 

--- a/app/Http/Controllers/User/ConsentCoverageController.php
+++ b/app/Http/Controllers/User/ConsentCoverageController.php
@@ -10,6 +10,7 @@ use App\Http\Resources\ConsentCoverageResource;
 use App\Models\ConsentCoverage;
 use App\Repositories\ConsentCoverageRepository;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
 
 class ConsentCoverageController extends Controller
 {
@@ -20,8 +21,9 @@ class ConsentCoverageController extends Controller
      */
     public function index(ListConsentCoverageRequest $request): JsonResponse
     {
+        $organizationId = Auth::user()->organization_id;
         $perPage = $request->input('per_page', 15);
-        $coverages = $this->consentCoverageRepository->getPaginatedCoverages($perPage);
+        $coverages = $this->consentCoverageRepository->getPaginatedCoverages($organizationId, $perPage);
 
         return response()->json([
             'error' => false,
@@ -36,6 +38,7 @@ class ConsentCoverageController extends Controller
     public function store(StoreConsentCoverageRequest $request): JsonResponse
     {
         $validated = $request->validated();
+        $validated['organization_id'] = $request->user()->organization_id;
 
         $coverage = $this->consentCoverageRepository->createCoverage($validated);
 

--- a/app/Http/Controllers/User/ConsentScopeController.php
+++ b/app/Http/Controllers/User/ConsentScopeController.php
@@ -10,6 +10,7 @@ use App\Http\Resources\ConsentScopeResource;
 use App\Models\ConsentScope;
 use App\Repositories\ConsentScopeRepository;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
 
 class ConsentScopeController extends Controller
 {
@@ -20,8 +21,9 @@ class ConsentScopeController extends Controller
      */
     public function index(ListConsentScopeRequest $request): JsonResponse
     {
+        $organizationId = Auth::user()->organization_id;
         $perPage = $request->input('per_page', 15);
-        $consentScopes = $this->consentScopeRepository->getPaginatedConsentScopes($perPage);
+        $consentScopes = $this->consentScopeRepository->getPaginatedConsentScopes($organizationId, $perPage);
 
         return response()->json([
             'error' => false,
@@ -36,6 +38,7 @@ class ConsentScopeController extends Controller
     public function store(StoreConsentScopeRequest $request): JsonResponse
     {
         $validated = $request->validated();
+        $validated['organization_id'] = $request->user()->organization_id;
 
         $consentScope = $this->consentScopeRepository->createConsentScope($validated);
 

--- a/app/Http/Controllers/User/DataElementController.php
+++ b/app/Http/Controllers/User/DataElementController.php
@@ -10,6 +10,7 @@ use App\Models\DataElement;
 use App\Repositories\DataElementRepository;
 use Illuminate\Http\JsonResponse;
 use App\Http\Resources\DataElementResource;
+use Illuminate\Support\Facades\Auth;
 
 class DataElementController extends Controller
 {
@@ -19,8 +20,9 @@ class DataElementController extends Controller
 
     public function index(ListDataElementRequest $request): JsonResponse
     {
+        $organizationId = Auth::user()->organization_id;
         $perPage = $request->validated('per_page', 15);
-        $dataElements = $this->repository->getPaginatedDataElements($perPage);
+        $dataElements = $this->repository->getPaginatedDataElements($organizationId, $perPage);
 
         return response()->json([
             'error' => false,
@@ -31,7 +33,9 @@ class DataElementController extends Controller
 
     public function store(StoreDataElementRequest $request): JsonResponse
     {
-        $dataElement = $this->repository->createDataElement($request->validated());
+        $validated = $request->validated();
+        $validated['organization_id'] = $request->user()->organization_id;
+        $dataElement = $this->repository->createDataElement($validated);
 
         return response()->json([
             'error' => false,

--- a/app/Http/Controllers/User/DataSourceController.php
+++ b/app/Http/Controllers/User/DataSourceController.php
@@ -10,6 +10,7 @@ use App\Models\DataSource;
 use App\Repositories\DataSourceRepository;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class DataSourceController extends Controller
 {
@@ -20,8 +21,9 @@ class DataSourceController extends Controller
      */
     public function index(ListDataSourceRequest $request): JsonResponse
     {
+        $organizationId = Auth::user()->organization_id;
         $perPage = $request->input('per_page', 15);
-        $dataSources = $this->dataSourceRepository->getPaginatedDataSources($perPage);
+        $dataSources = $this->dataSourceRepository->getPaginatedDataSources($organizationId, $perPage);
 
         return response()->json([
             'error' => false,
@@ -36,6 +38,7 @@ class DataSourceController extends Controller
     public function store(StoreDataSourceRequest $request): JsonResponse
     {
         $validated = $request->validated();
+        $validated['organization_id'] = $request->user()->organization_id;
 
         $dataSource = $this->dataSourceRepository->createDataSource($validated);
 

--- a/app/Http/Controllers/User/DatasetController.php
+++ b/app/Http/Controllers/User/DatasetController.php
@@ -10,6 +10,7 @@ use App\Http\Resources\DatasetResource;
 use App\Models\Dataset;
 use App\Repositories\DatasetRepository;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
 
 class DatasetController extends Controller
 {
@@ -20,8 +21,9 @@ class DatasetController extends Controller
      */
     public function index(ListDatasetRequest $request): JsonResponse
     {
+        $organizationId = Auth::user()->organization_id;
         $perPage = $request->input('per_page', 15);
-        $datasets = $this->datasetRepository->getPaginatedDatasets($perPage);
+        $datasets = $this->datasetRepository->getPaginatedDatasets($organizationId, $perPage);
 
         return response()->json([
             'error' => false,
@@ -36,6 +38,7 @@ class DatasetController extends Controller
     public function store(StoreDatasetRequest $request): JsonResponse
     {
         $validated = $request->validated();
+        $validated['organization_id'] = $request->user()->organization_id;
 
         $dataset = $this->datasetRepository->createDataset($validated);
 

--- a/app/Http/Controllers/User/DatasetSnapshotController.php
+++ b/app/Http/Controllers/User/DatasetSnapshotController.php
@@ -10,6 +10,7 @@ use App\Http\Resources\DatasetSnapshotResource;
 use App\Models\DatasetSnapshot;
 use App\Repositories\DatasetSnapshotRepository;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
 
 class DatasetSnapshotController extends Controller
 {
@@ -20,8 +21,9 @@ class DatasetSnapshotController extends Controller
      */
     public function index(ListDatasetSnapshotRequest $request): JsonResponse
     {
+        $organizationId = Auth::user()->organization_id;
         $perPage = $request->input('per_page', 15);
-        $snapshots = $this->datasetSnapshotRepository->getPaginatedSnapshots($perPage);
+        $snapshots = $this->datasetSnapshotRepository->getPaginatedSnapshots($organizationId, $perPage);
 
         return response()->json([
             'error' => false,
@@ -36,6 +38,7 @@ class DatasetSnapshotController extends Controller
     public function store(StoreDatasetSnapshotRequest $request): JsonResponse
     {
         $validated = $request->validated();
+        $validated['organization_id'] = $request->user()->organization_id;
 
         $snapshot = $this->datasetSnapshotRepository->createSnapshot($validated);
 

--- a/app/Http/Controllers/User/DatasetSubjectPopulationController.php
+++ b/app/Http/Controllers/User/DatasetSubjectPopulationController.php
@@ -10,6 +10,7 @@ use App\Models\DatasetSubjectPopulation;
 use App\Repositories\DatasetSubjectPopulationRepository;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class DatasetSubjectPopulationController extends Controller
 {
@@ -22,8 +23,9 @@ class DatasetSubjectPopulationController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
+        $organizationId = Auth::user()->organization_id;
         $perPage = $request->input('per_page', 15);
-        $populations = $this->repository->getPaginatedPopulations($perPage);
+        $populations = $this->repository->getPaginatedPopulations($organizationId, $perPage);
 
         return response()->json([
             'error' => false,
@@ -37,7 +39,9 @@ class DatasetSubjectPopulationController extends Controller
      */
     public function store(StoreDatasetSubjectPopulationRequest $request): JsonResponse
     {
-        $population = $this->repository->createPopulation($request->validated());
+        $validated = $request->validated();
+        $validated['organization_id'] = $request->user()->organization_id;
+        $population = $this->repository->createPopulation($validated);
 
         return response()->json([
             'error' => false,

--- a/app/Http/Controllers/User/PdpProcessingRegisterController.php
+++ b/app/Http/Controllers/User/PdpProcessingRegisterController.php
@@ -10,6 +10,7 @@ use App\Models\PdpProcessingRegister;
 use App\Repositories\PdpProcessingRegisterRepository;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class PdpProcessingRegisterController extends Controller
 {
@@ -22,8 +23,9 @@ class PdpProcessingRegisterController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
+        $organizationId = Auth::user()->organization_id;
         $perPage = $request->input('per_page', 15);
-        $registers = $this->repository->getPaginatedRegisters($perPage);
+        $registers = $this->repository->getPaginatedRegisters($organizationId, $perPage);
 
         return response()->json([
             'error' => false,
@@ -37,7 +39,9 @@ class PdpProcessingRegisterController extends Controller
      */
     public function store(StorePdpProcessingRegisterRequest $request): JsonResponse
     {
-        $register = $this->repository->createRegister($request->validated());
+        $validated = $request->validated();
+        $validated['organization_id'] = $request->user()->organization_id;
+        $register = $this->repository->createRegister($validated);
 
         return response()->json([
             'error' => false,

--- a/app/Http/Controllers/User/StakeholderController.php
+++ b/app/Http/Controllers/User/StakeholderController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\StoreStakeholderRequest;
 use App\Models\Stakeholder;
 use App\Repositories\StakeholderRepository;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
 
 class StakeholderController extends Controller
 {
@@ -16,6 +17,7 @@ class StakeholderController extends Controller
     public function index(ListStakeholderRequest $request): JsonResponse
     {
         $filters = $request->validated();
+        $filters['organization_id'] = Auth::user()->organization_id;
         $stakeholders = $this->stakeholderRepository->getFilteredStakeholders($filters);
 
         return response()->json([
@@ -28,6 +30,7 @@ class StakeholderController extends Controller
     public function store(StoreStakeholderRequest $request): JsonResponse
     {
         $validated = $request->validated();
+        $validated['organization_id'] = $request->user()->organization_id;
         $stakeholder = $this->stakeholderRepository->create($validated);
 
         return response()->json([

--- a/app/Http/Controllers/User/UseCaseController.php
+++ b/app/Http/Controllers/User/UseCaseController.php
@@ -9,6 +9,7 @@ use App\Models\UseCase;
 use App\Repositories\UseCaseRepository;
 use Illuminate\Http\JsonResponse;
 use App\Http\Resources\UseCaseResource;
+use Illuminate\Support\Facades\Auth;
 
 class UseCaseController extends Controller
 {
@@ -16,7 +17,9 @@ class UseCaseController extends Controller
 
     public function index(SearchUseCaseRequest $request): JsonResponse
     {
-        $useCases = $this->repository->getFilteredUseCases($request->validated());
+        $filters = $request->validated();
+        $filters['organization_id'] = Auth::user()->organization_id;
+        $useCases = $this->repository->getFilteredUseCases($filters);
         return response()->json([
             'data' => $useCases,
             'error' => false,
@@ -27,6 +30,7 @@ class UseCaseController extends Controller
     public function store(StoreUseCaseRequest $request): JsonResponse
     {
         $data = $request->validated();
+        $data['organization_id'] = $request->user()->organization_id;
         $this->repository->createUseCase($data);
 
         return response()->json([

--- a/app/Http/Controllers/User/UserConsentController.php
+++ b/app/Http/Controllers/User/UserConsentController.php
@@ -10,6 +10,7 @@ use App\Http\Resources\UserConsentResource;
 use App\Models\UserConsent;
 use App\Repositories\UserConsentRepository;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Auth;
 
 class UserConsentController extends Controller
 {
@@ -20,8 +21,9 @@ class UserConsentController extends Controller
      */
     public function index(ListUserConsentRequest $request): JsonResponse
     {
+        $organizationId = Auth::user()->organization_id;
         $perPage = $request->input('per_page', 15);
-        $consents = $this->userConsentRepository->getPaginatedConsents($perPage);
+        $consents = $this->userConsentRepository->getPaginatedConsents($organizationId, $perPage);
 
         return response()->json([
             'error' => false,
@@ -36,6 +38,7 @@ class UserConsentController extends Controller
     public function store(StoreUserConsentRequest $request): JsonResponse
     {
         $validated = $request->validated();
+        $validated['organization_id'] = $request->user()->organization_id;
 
         $consent = $this->userConsentRepository->createConsent($validated);
 

--- a/app/Http/Requests/DatasetElementMap/StoreDatasetElementMapRequest.php
+++ b/app/Http/Requests/DatasetElementMap/StoreDatasetElementMapRequest.php
@@ -21,6 +21,7 @@ class StoreDatasetElementMapRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'organization_id' => ['required', 'integer', 'exists:organizations,id'],
             'dataset_id' => ['required', 'integer', 'exists:datasets,id'],
             'data_element_id' => ['required', 'integer', 'exists:data_elements,id'],
             'column_name' => ['required', 'string', 'max:255'],

--- a/app/Models/AiModelCard.php
+++ b/app/Models/AiModelCard.php
@@ -12,6 +12,7 @@ class AiModelCard extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'ai_model_id',
         'ai_model_version_id',
         'title',

--- a/app/Models/AiModelDataset.php
+++ b/app/Models/AiModelDataset.php
@@ -16,6 +16,7 @@ class AiModelDataset extends Model
     protected $table = 'ai_model_dataset';
 
     protected $fillable = [
+        'organization_id',
         'ai_model_id',
         'ai_model_version_id',
         'dataset_id',

--- a/app/Models/AiModelUseCase.php
+++ b/app/Models/AiModelUseCase.php
@@ -11,6 +11,7 @@ class AiModelUseCase extends Model
     /** @use HasFactory<\Database\Factories\AiModelUseCaseFactory> */
     use HasFactory;
     protected $fillable = [
+        'organization_id',
         'ai_model_id',
         'use_case_id',
         'ai_model_version_id',

--- a/app/Models/AiModelVersion.php
+++ b/app/Models/AiModelVersion.php
@@ -11,6 +11,7 @@ class AiModelVersion extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'ai_model_id',
         'version_number',
         'version_type',

--- a/app/Models/ConsentCoverage.php
+++ b/app/Models/ConsentCoverage.php
@@ -12,6 +12,7 @@ class ConsentCoverage extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'dataset_id',
         'snapshot_id',
         'purpose',

--- a/app/Models/ConsentScope.php
+++ b/app/Models/ConsentScope.php
@@ -15,6 +15,7 @@ class ConsentScope extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'dataset_id',
         'purpose',
         'subject_realm',

--- a/app/Models/DataElement.php
+++ b/app/Models/DataElement.php
@@ -12,6 +12,7 @@ class DataElement extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'name',
         'business_definition',
         'data_type',

--- a/app/Models/DataSource.php
+++ b/app/Models/DataSource.php
@@ -11,6 +11,7 @@ class DataSource extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'name',
         'system_type',
         'owner_team',

--- a/app/Models/Dataset.php
+++ b/app/Models/Dataset.php
@@ -13,6 +13,7 @@ class Dataset extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'dataset_id',
         'name',
         'source_ids',

--- a/app/Models/DatasetDataElement.php
+++ b/app/Models/DatasetDataElement.php
@@ -14,6 +14,7 @@ class DatasetDataElement extends Model
     protected $table = 'dataset_element';
 
     protected $fillable = [
+        'organization_id',
         'dataset_id',
         'data_element_id',
         'column_name',

--- a/app/Models/DatasetSnapshot.php
+++ b/app/Models/DatasetSnapshot.php
@@ -12,6 +12,7 @@ class DatasetSnapshot extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'dataset_id',
         'version_tag',
         'time_range_start',

--- a/app/Models/DatasetSubjectPopulation.php
+++ b/app/Models/DatasetSubjectPopulation.php
@@ -13,6 +13,7 @@ class DatasetSubjectPopulation extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'dataset_id',
         'snapshot_id',
         'subject_realm',

--- a/app/Models/PdpProcessingRegister.php
+++ b/app/Models/PdpProcessingRegister.php
@@ -11,6 +11,7 @@ class PdpProcessingRegister extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'purpose',
         'controller_role',
         'data_subject_categories',

--- a/app/Models/Stakeholder.php
+++ b/app/Models/Stakeholder.php
@@ -11,6 +11,7 @@ class Stakeholder extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'type',
         'display_name',
         'legal_name',

--- a/app/Models/UseCase.php
+++ b/app/Models/UseCase.php
@@ -11,6 +11,7 @@ class UseCase extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'name',
         'description',
         'business_objective',

--- a/app/Models/UserConsent.php
+++ b/app/Models/UserConsent.php
@@ -16,6 +16,7 @@ class UserConsent extends Model
     use HasFactory;
 
     protected $fillable = [
+        'organization_id',
         'subject_key',
         'subject_realm',
         'jurisdiction',

--- a/app/Repositories/AiModelCardRepository.php
+++ b/app/Repositories/AiModelCardRepository.php
@@ -13,9 +13,9 @@ class AiModelCardRepository
      * @param int $perPage
      * @return LengthAwarePaginator<int, AiModelCard>
      */
-    public function getPaginatedAiModelCards(int $perPage): LengthAwarePaginator
+    public function getPaginatedAiModelCardsByOrganizationID(int $organizationId, int $perPage): LengthAwarePaginator
     {
-        return AiModelCard::paginate($perPage);
+        return AiModelCard::where('organization_id', $organizationId)->paginate($perPage);
     }
 
     public function createAiModelCard(array $data): AiModelCard

--- a/app/Repositories/AiModelDatasetRepository.php
+++ b/app/Repositories/AiModelDatasetRepository.php
@@ -10,14 +10,15 @@ use Illuminate\Pagination\LengthAwarePaginator;
 class AiModelDatasetRepository
 {
     /**
-     * Get paginated AI model datasets.
+     * Get paginated AI model datasets for a specific organization.
      *
+     * @param int $organizationId
      * @param int $perPage
      * @return LengthAwarePaginator<int, AiModelDataset>
      */
-    public function getPaginatedAiModelDatasets(int $perPage): LengthAwarePaginator
+    public function getPaginatedAiModelDatasets(int $organizationId, int $perPage): LengthAwarePaginator
     {
-        return AiModelDataset::paginate($perPage);
+        return AiModelDataset::where('organization_id', $organizationId)->paginate($perPage);
     }
 
     /**

--- a/app/Repositories/AiModelUseCaseRepository.php
+++ b/app/Repositories/AiModelUseCaseRepository.php
@@ -17,6 +17,10 @@ class AiModelUseCaseRepository
     {
         $query = AiModelUseCase::with(['aiModel', 'useCase', 'aiModelVersion']);
 
+        if (isset($filters['organization_id'])) {
+            $query->where('organization_id', $filters['organization_id']);
+        }
+
         if (isset($filters['ai_model_id'])) {
             $query->where('ai_model_id', $filters['ai_model_id']);
         }

--- a/app/Repositories/AiModelVersionRepository.php
+++ b/app/Repositories/AiModelVersionRepository.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Collection;
 class AiModelVersionRepository
 {
     /**
-     * Retrieve all AI model versions, optionally filtered by AI model ID.
+     * Retrieve all AI model versions, optionally filtered by AI model ID and organization.
      *
      * @param array $filters
      * @return \Illuminate\Database\Eloquent\Collection<int, AiModelVersion>
@@ -16,6 +16,10 @@ class AiModelVersionRepository
     public function getFilteredAiModelVersions(array $filters = []): Collection
     {
         $query = AiModelVersion::query();
+
+        if (isset($filters['organization_id'])) {
+            $query->where('organization_id', $filters['organization_id']);
+        }
 
         if (isset($filters['ai_model_id'])) {
             $query->where('ai_model_id', $filters['ai_model_id']);

--- a/app/Repositories/ConsentCoverageRepository.php
+++ b/app/Repositories/ConsentCoverageRepository.php
@@ -12,14 +12,16 @@ use Illuminate\Support\Collection;
 class ConsentCoverageRepository
 {
     /**
-     * Get paginated consent coverages.
+     * Get paginated consent coverages for a specific organization.
      *
+     * @param int $organizationId
      * @param int $perPage
      * @return LengthAwarePaginator<int, ConsentCoverage>
      */
-    public function getPaginatedCoverages(int $perPage = 15): LengthAwarePaginator
+    public function getPaginatedCoverages(int $organizationId, int $perPage = 15): LengthAwarePaginator
     {
-        return ConsentCoverage::with(['dataset', 'snapshot'])
+        return ConsentCoverage::where('organization_id', $organizationId)
+            ->with(['dataset', 'snapshot'])
             ->orderBy('as_of', 'desc')
             ->paginate($perPage);
     }

--- a/app/Repositories/ConsentScopeRepository.php
+++ b/app/Repositories/ConsentScopeRepository.php
@@ -13,14 +13,16 @@ use Illuminate\Support\Collection;
 class ConsentScopeRepository
 {
     /**
-     * Get paginated consent scopes.
+     * Get paginated consent scopes for a specific organization.
      *
+     * @param int $organizationId
      * @param int $perPage
      * @return LengthAwarePaginator<int, ConsentScope>
      */
-    public function getPaginatedConsentScopes(int $perPage = 15): LengthAwarePaginator
+    public function getPaginatedConsentScopes(int $organizationId, int $perPage = 15): LengthAwarePaginator
     {
-        return ConsentScope::with('dataset')
+        return ConsentScope::where('organization_id', $organizationId)
+            ->with('dataset')
             ->orderBy('created_at', 'desc')
             ->paginate($perPage);
     }

--- a/app/Repositories/DataElementRepository.php
+++ b/app/Repositories/DataElementRepository.php
@@ -9,13 +9,14 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 class DataElementRepository
 {
     /**
-     * Get paginated data elements.
+     * Get paginated data elements for a specific organization.
+     * @param int $organizationId
      * @param int $perPage
      * @return LengthAwarePaginator<int, DataElement>
      */
-    public function getPaginatedDataElements(int $perPage = 15): LengthAwarePaginator
+    public function getPaginatedDataElements(int $organizationId, int $perPage = 15): LengthAwarePaginator
     {
-        $query = DataElement::query()->with('datasets');
+        $query = DataElement::where('organization_id', $organizationId)->with('datasets');
         return $query->paginate($perPage);
     }
 

--- a/app/Repositories/DataSourceRepository.php
+++ b/app/Repositories/DataSourceRepository.php
@@ -8,14 +8,15 @@ use Illuminate\Pagination\LengthAwarePaginator;
 class DataSourceRepository
 {
     /**
-     * Get paginated data sources.
+     * Get paginated data sources for a specific organization.
      *
+     * @param int $organizationId
      * @param int $perPage
      * @return LengthAwarePaginator<int , DataSource>
      */
-    public function getPaginatedDataSources(int $perPage = 15): LengthAwarePaginator
+    public function getPaginatedDataSources(int $organizationId, int $perPage = 15): LengthAwarePaginator
     {
-        return DataSource::paginate($perPage);
+        return DataSource::where('organization_id', $organizationId)->paginate($perPage);
     }
 
     /**

--- a/app/Repositories/DatasetRepository.php
+++ b/app/Repositories/DatasetRepository.php
@@ -8,14 +8,15 @@ use Illuminate\Pagination\LengthAwarePaginator;
 class DatasetRepository
 {
     /**
-     * Get paginated datasets.
+     * Get paginated datasets for a specific organization.
      *
+     * @param int $organizationId
      * @param int $perPage
      * @return LengthAwarePaginator<int, Dataset>
      */
-    public function getPaginatedDatasets(int $perPage = 15): LengthAwarePaginator
+    public function getPaginatedDatasets(int $organizationId, int $perPage = 15): LengthAwarePaginator
     {
-        $query = Dataset::with(['dataElements']);
+        $query = Dataset::where('organization_id', $organizationId)->with(['dataElements']);
         return $query->paginate($perPage);
     }
 

--- a/app/Repositories/DatasetSnapshotRepository.php
+++ b/app/Repositories/DatasetSnapshotRepository.php
@@ -10,14 +10,15 @@ use Illuminate\Support\Collection;
 class DatasetSnapshotRepository
 {
     /**
-     * Get paginated dataset snapshots.
+     * Get paginated dataset snapshots for a specific organization.
      *
+     * @param int $organizationId
      * @param int $perPage
      * @return LengthAwarePaginator<int, DatasetSnapshot>
      */
-    public function getPaginatedSnapshots(int $perPage = 15): LengthAwarePaginator
+    public function getPaginatedSnapshots(int $organizationId, int $perPage = 15): LengthAwarePaginator
     {
-        return DatasetSnapshot::with('dataset')->paginate($perPage);
+        return DatasetSnapshot::where('organization_id', $organizationId)->with('dataset')->paginate($perPage);
     }
 
     /**

--- a/app/Repositories/DatasetSubjectPopulationRepository.php
+++ b/app/Repositories/DatasetSubjectPopulationRepository.php
@@ -8,11 +8,16 @@ use Illuminate\Pagination\LengthAwarePaginator;
 class DatasetSubjectPopulationRepository
 {
     /**
+     * Get paginated dataset subject populations for a specific organization.
+     * 
+     * @param int $organizationId
+     * @param int $perPage
      * @return LengthAwarePaginator<int, DatasetSubjectPopulation>
      */
-    public function getPaginatedPopulations(int $perPage = 15): LengthAwarePaginator
+    public function getPaginatedPopulations(int $organizationId, int $perPage = 15): LengthAwarePaginator
     {
-        return DatasetSubjectPopulation::with(['dataset', 'snapshot'])
+        return DatasetSubjectPopulation::where('organization_id', $organizationId)
+            ->with(['dataset', 'snapshot'])
             ->orderBy('as_of', 'desc')
             ->paginate($perPage);
     }

--- a/app/Repositories/PdpProcessingRegisterRepository.php
+++ b/app/Repositories/PdpProcessingRegisterRepository.php
@@ -8,11 +8,16 @@ use Illuminate\Pagination\LengthAwarePaginator;
 class PdpProcessingRegisterRepository
 {
     /**
+     * Get paginated PDP processing registers for a specific organization.
+     * 
+     * @param int $organizationId
+     * @param int $perPage
      * @return LengthAwarePaginator<int, PdpProcessingRegister>
      */
-    public function getPaginatedRegisters(int $perPage = 15): LengthAwarePaginator
+    public function getPaginatedRegisters(int $organizationId, int $perPage = 15): LengthAwarePaginator
     {
-        return PdpProcessingRegister::orderBy('created_at', 'desc')
+        return PdpProcessingRegister::where('organization_id', $organizationId)
+            ->orderBy('created_at', 'desc')
             ->paginate($perPage);
     }
 

--- a/app/Repositories/StakeholderRepository.php
+++ b/app/Repositories/StakeholderRepository.php
@@ -18,6 +18,10 @@ class StakeholderRepository
     {
         $query = Stakeholder::query();
 
+        if (!empty($filters['organization_id'])) {
+            $query->where('organization_id', $filters['organization_id']);
+        }
+
         if (!empty($filters['type'])) {
             $query->where('type', $filters['type']);
         }

--- a/app/Repositories/UseCaseRepository.php
+++ b/app/Repositories/UseCaseRepository.php
@@ -18,6 +18,10 @@ class UseCaseRepository
     {
         $query = UseCase::query();
 
+        $query->when(! empty($filters['organization_id']), function ($query) use ($filters) {
+            $query->where('organization_id', $filters['organization_id']);
+        });
+
         $query->when(! empty($filters['name']), function ($query) use ($filters) {
             $query->where('name', 'like', '%' . $filters['name'] . '%');
         });

--- a/app/Repositories/UserConsentRepository.php
+++ b/app/Repositories/UserConsentRepository.php
@@ -10,14 +10,17 @@ use Illuminate\Support\Collection;
 class UserConsentRepository
 {
     /**
-     * Get paginated user consents.
+     * Get paginated user consents for a specific organization.
      *
+     * @param int $organizationId
      * @param int $perPage
      * @return LengthAwarePaginator<int, UserConsent>
      */
-    public function getPaginatedConsents(int $perPage = 15): LengthAwarePaginator
+    public function getPaginatedConsents(int $organizationId, int $perPage = 15): LengthAwarePaginator
     {
-        return UserConsent::orderBy('created_at', 'desc')->paginate($perPage);
+        return UserConsent::where('organization_id', $organizationId)
+            ->orderBy('created_at', 'desc')
+            ->paginate($perPage);
     }
 
     /**

--- a/database/factories/AiModelCardFactory.php
+++ b/database/factories/AiModelCardFactory.php
@@ -13,6 +13,7 @@ use App\Enums\TechnicalReviewStatus;
 use App\Enums\EthicsReviewStatus;
 use App\Enums\ComplianceReviewStatus;
 use App\Enums\PublicationStatus;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -28,6 +29,7 @@ class AiModelCardFactory extends Factory
     public function definition(): array
     {
         return [
+            'organization_id' => Organization::factory(),
             'ai_model_id' => AiModel::factory(),
             'ai_model_version_id' => AiModelVersion::factory(),
             'title' => $this->faker->sentence,

--- a/database/factories/AiModelDatasetFactory.php
+++ b/database/factories/AiModelDatasetFactory.php
@@ -9,6 +9,7 @@ use App\Models\AiModelDataset;
 use App\Models\AiModelVersion;
 use App\Models\Dataset;
 use App\Models\DatasetSnapshot;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -36,6 +37,7 @@ class AiModelDatasetFactory extends Factory
         ]);
 
         return [
+            'organization_id' => Organization::factory(),
             'ai_model_id' => AiModel::factory(),
             'ai_model_version_id' => AiModelVersion::factory(),
             'dataset_id' => fake()->optional(0.7)->passthrough(Dataset::factory()),

--- a/database/factories/AiModelUseCaseFactory.php
+++ b/database/factories/AiModelUseCaseFactory.php
@@ -7,6 +7,7 @@ use App\Models\AiModel;
 use App\Models\UseCase;
 use App\Models\AiModelVersion;
 use App\Models\User;
+use App\Models\Organization;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\AiModelUseCase>
@@ -21,6 +22,7 @@ class AiModelUseCaseFactory extends Factory
     public function definition(): array
     {
         return [
+            'organization_id' => Organization::factory(),
             'ai_model_id' => AiModel::factory(),
             'use_case_id' => UseCase::factory(),
             'ai_model_version_id' => AiModelVersion::factory(),

--- a/database/factories/AiModelVersionFactory.php
+++ b/database/factories/AiModelVersionFactory.php
@@ -10,6 +10,7 @@ use App\Enums\ValidationStatus;
 use App\Enums\VersionType;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use App\Models\AiModel;
+use App\Models\Organization;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\AiModelVersion>
@@ -24,6 +25,7 @@ class AiModelVersionFactory extends Factory
     public function definition(): array
     {
         return [
+            'organization_id' => Organization::factory(),
             'ai_model_id' => AiModel::factory(),
             'version_number' => $this->faker->unique()->numerify('v#.##'),
             'version_type' => VersionType::MAJOR,

--- a/database/factories/ConsentCoverageFactory.php
+++ b/database/factories/ConsentCoverageFactory.php
@@ -6,6 +6,7 @@ use App\Enums\UserConsent\ConsentPurpose;
 use App\Enums\UserConsent\Jurisdiction;
 use App\Models\Dataset;
 use App\Models\DatasetSnapshot;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -33,6 +34,7 @@ class ConsentCoverageFactory extends Factory
         $purposeValues = array_map(fn($purpose) => $purpose->value, $selectedPurposes);
 
         return [
+            'organization_id' => Organization::factory(),
             'dataset_id' => Dataset::factory(),
             'snapshot_id' => fake()->boolean(70) ? DatasetSnapshot::factory() : null,
             'purpose' => $purposeValues,

--- a/database/factories/ConsentScopeFactory.php
+++ b/database/factories/ConsentScopeFactory.php
@@ -6,6 +6,7 @@ use App\Enums\UserConsent\ConsentPurpose;
 use App\Enums\UserConsent\Jurisdiction;
 use App\Enums\UserConsent\SubjectRealm;
 use App\Models\Dataset;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -27,6 +28,7 @@ class ConsentScopeFactory extends Factory
         $purposeValues = array_map(fn($purpose) => $purpose->value, $selectedPurposes);
 
         return [
+            'organization_id' => Organization::factory(),
             'dataset_id' => Dataset::factory(),
             'purpose' => $purposeValues,
             'subject_realm' => fake()->randomElement(SubjectRealm::cases()),

--- a/database/factories/DataElementFactory.php
+++ b/database/factories/DataElementFactory.php
@@ -10,6 +10,7 @@ use App\Enums\DataElement\PiiFlag;
 use App\Enums\DataElement\Sensitivity;
 use App\Enums\DataElement\SpecialCategoryFlag;
 use App\Models\DataElement;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -27,6 +28,7 @@ class DataElementFactory extends Factory
     public function definition(): array
     {
         return [
+            'organization_id' => Organization::factory(),
             'name' => fake()->words(3, true),
             'business_definition' => fake()->sentence(),
             'data_type' => fake()->randomElement(DataType::cases()),

--- a/database/factories/DataSourceFactory.php
+++ b/database/factories/DataSourceFactory.php
@@ -9,6 +9,7 @@ use App\Enums\DataSource\DataResidency;
 use App\Enums\DataSource\HostingModel;
 use App\Enums\DataSource\ServiceModel;
 use App\Enums\DataSource\SystemType;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -24,6 +25,7 @@ class DataSourceFactory extends Factory
     public function definition(): array
     {
         return [
+            'organization_id' => Organization::factory(),
             'name' => fake()->company() . ' ' . fake()->randomElement(['Database', 'Data Lake', 'API', 'Storage']),
             'system_type' => fake()->randomElement(SystemType::cases()),
             'owner_team' => fake()->randomElement(['Engineering', 'Data Science', 'Analytics', 'Operations', 'Product']),

--- a/database/factories/DatasetDataElementFactory.php
+++ b/database/factories/DatasetDataElementFactory.php
@@ -11,6 +11,7 @@ use App\Enums\DatasetElementMap\SensitivityOverride;
 use App\Models\DataElement;
 use App\Models\Dataset;
 use App\Models\DatasetDataElement;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -28,6 +29,7 @@ class DatasetDataElementFactory extends Factory
     public function definition(): array
     {
         return [
+            'organization_id' => Organization::factory(),
             'dataset_id' => Dataset::factory(),
             'data_element_id' => DataElement::factory(),
             'column_name' => fake()->word(),

--- a/database/factories/DatasetFactory.php
+++ b/database/factories/DatasetFactory.php
@@ -13,6 +13,7 @@ use App\Enums\Dataset\Purpose;
 use App\Enums\Dataset\Sensitivity;
 use App\Enums\Dataset\StorageFormat;
 use App\Models\DataSource;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -32,6 +33,7 @@ class DatasetFactory extends Factory
         $consentRequired = $lawfulBasis === LawfulBasis::CONSENT;
 
         return [
+            'organization_id' => Organization::factory(),
             'name' => fake()->words(3, true) . ' Dataset',
             'source_ids' => fake()->randomElements(
                 DataSource::pluck('id')->toArray() ?: [1, 2, 3],

--- a/database/factories/DatasetSnapshotFactory.php
+++ b/database/factories/DatasetSnapshotFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Enums\DatasetSnapshot\ResidencyZone;
 use App\Models\Dataset;
 use App\Models\DatasetSnapshot;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -22,6 +23,7 @@ class DatasetSnapshotFactory extends Factory
     public function definition(): array
     {
         return [
+            'organization_id' => Organization::factory(),
             'dataset_id' => Dataset::factory(),
             'version_tag' => fake()->randomElement(['v1.0', 'v1.1', 'v2.0', 'v2.1', 'v3.0']),
             'time_range_start' => fake()->optional()->dateTimeBetween('-1 year', '-1 month'),

--- a/database/factories/DatasetSubjectPopulationFactory.php
+++ b/database/factories/DatasetSubjectPopulationFactory.php
@@ -7,6 +7,7 @@ use App\Enums\UserConsent\SubjectRealm;
 use App\Models\Dataset;
 use App\Models\DatasetSnapshot;
 use App\Models\DatasetSubjectPopulation;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -24,6 +25,7 @@ class DatasetSubjectPopulationFactory extends Factory
     public function definition(): array
     {
         return [
+            'organization_id' => Organization::factory(),
             'dataset_id' => Dataset::factory(),
             'snapshot_id' => $this->faker->boolean(70) ? DatasetSnapshot::factory() : null,
             'subject_realm' => $this->faker->randomElement(SubjectRealm::cases())->value,

--- a/database/factories/PdpProcessingRegisterFactory.php
+++ b/database/factories/PdpProcessingRegisterFactory.php
@@ -6,6 +6,7 @@ use App\Enums\Status;
 use App\Enums\UserConsent\LegalBasis;
 use App\Enums\UserConsent\SubjectRealm;
 use App\Models\PdpProcessingRegister;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -33,6 +34,7 @@ class PdpProcessingRegisterFactory extends Factory
         );
 
         return [
+            'organization_id' => Organization::factory(),
             'purpose' => $this->faker->randomElement([
                 'Fraud detection',
                 'Service personalization',

--- a/database/factories/StakeholderFactory.php
+++ b/database/factories/StakeholderFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use App\Enums\Stakeholder\Type;
 use App\Models\Stakeholder;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -26,6 +27,7 @@ class StakeholderFactory extends Factory
     public function definition(): array
     {
         return [
+            'organization_id' => Organization::factory(),
             'type' => fake()->randomElement(Type::cases())->value,
             'display_name' => fake()->name(),
             'legal_name' => fake()->optional()->company(),

--- a/database/factories/UseCaseFactory.php
+++ b/database/factories/UseCaseFactory.php
@@ -11,6 +11,7 @@ use App\Enums\UseCase\RiskLevel;
 use App\Enums\UseCase\ROIClassification;
 use App\Enums\UseCase\Status;
 use App\Models\Stakeholder;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -26,6 +27,7 @@ class UseCaseFactory extends Factory
     public function definition(): array
     {
         return [
+            'organization_id' => Organization::factory(),
             'name' => $this->faker->sentence(3),
             'description' => $this->faker->paragraphs(3, true),
             'business_objective' => $this->faker->paragraphs(2, true),

--- a/database/factories/UserConsentFactory.php
+++ b/database/factories/UserConsentFactory.php
@@ -8,6 +8,7 @@ use App\Enums\UserConsent\Jurisdiction;
 use App\Enums\UserConsent\LegalBasis;
 use App\Enums\UserConsent\SubjectRealm;
 use App\Models\UserConsent;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -31,6 +32,7 @@ class UserConsentFactory extends Factory
         $purposeValues = array_map(fn($purpose) => $purpose->value, $selectedPurposes);
 
         return [
+            'organization_id' => Organization::factory(),
             'subject_key' => fake()->unique()->regexify('[A-Z0-9]{32}'),
             'subject_realm' => fake()->randomElement(SubjectRealm::cases()),
             'jurisdiction' => fake()->randomElement(Jurisdiction::cases()),

--- a/database/migrations/2025_10_31_120000_add_organization_id_to_multiple_tables.php
+++ b/database/migrations/2025_10_31_120000_add_organization_id_to_multiple_tables.php
@@ -1,0 +1,197 @@
+<?php
+
+use App\Models\Organization;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Add organization_id to ai_model_versions
+        Schema::table('ai_model_versions', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to ai_model_cards
+        Schema::table('ai_model_cards', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to use_cases
+        Schema::table('use_cases', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to ai_model_use_cases
+        Schema::table('ai_model_use_cases', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to stakeholders
+        Schema::table('stakeholders', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to data_sources
+        Schema::table('data_sources', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to datasets
+        Schema::table('datasets', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to data_elements
+        Schema::table('data_elements', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to dataset_element (pivot table)
+        Schema::table('dataset_element', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to dataset_snapshots
+        Schema::table('dataset_snapshots', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to ai_model_dataset
+        Schema::table('ai_model_dataset', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to user_consents
+        Schema::table('user_consents', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to consent_scopes
+        Schema::table('consent_scopes', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to consent_coverages
+        Schema::table('consent_coverages', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to dataset_subject_populations
+        Schema::table('dataset_subject_populations', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+
+        // Add organization_id to pdp_processing_registers
+        Schema::table('pdp_processing_registers', function (Blueprint $table) {
+            $table->foreignIdFor(Organization::class)->after('id')->constrained()->cascadeOnDelete();
+            $table->index('organization_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('ai_model_versions', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('ai_model_cards', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('use_cases', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('ai_model_use_cases', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('stakeholders', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('data_sources', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('datasets', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('data_elements', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('dataset_element', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('dataset_snapshots', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('ai_model_dataset', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('user_consents', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('consent_scopes', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('consent_coverages', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('dataset_subject_populations', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('pdp_processing_registers', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->dropColumn('organization_id');
+        });
+    }
+};

--- a/tests/Feature/Controllers/User/AiModelCardControllerTest.php
+++ b/tests/Feature/Controllers/User/AiModelCardControllerTest.php
@@ -16,6 +16,7 @@ use App\Enums\EthicsReviewStatus;
 use App\Enums\ComplianceReviewStatus;
 use App\Enums\CreatorRole;
 use App\Enums\PublicationStatus;
+use App\Models\Organization;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -23,13 +24,22 @@ class AiModelCardControllerTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 
+    private Organization $organization;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->organization = Organization::factory()->create();
+    }
+
     public function test_user_can_list_ai_model_cards(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $aiModel = AiModel::factory()->create();
-        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $aiModelVersion = AiModelVersion::factory()->create(['organization_id' => $this->organization->id, 'ai_model_id' => $aiModel->id]);
 
         AiModelCard::factory()->count(3)->create([
+            'organization_id' => $this->organization->id,
             'ai_model_id' => $aiModel->id,
             'ai_model_version_id' => $aiModelVersion->id,
         ]);
@@ -59,11 +69,12 @@ class AiModelCardControllerTest extends TestCase
 
     public function test_user_can_list_ai_model_cards_with_custom_per_page(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $aiModel = AiModel::factory()->create();
-        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $aiModelVersion = AiModelVersion::factory()->create(['organization_id' => $this->organization->id, 'ai_model_id' => $aiModel->id]);
 
         AiModelCard::factory()->count(10)->create([
+            'organization_id' => $this->organization->id,
             'ai_model_id' => $aiModel->id,
             'ai_model_version_id' => $aiModelVersion->id,
         ]);
@@ -79,10 +90,11 @@ class AiModelCardControllerTest extends TestCase
 
     public function test_user_can_view_single_ai_model_card(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $aiModel = AiModel::factory()->create();
-        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $aiModelVersion = AiModelVersion::factory()->create(['organization_id' => $this->organization->id, 'ai_model_id' => $aiModel->id]);
         $aiModelCard = AiModelCard::factory()->create([
+            'organization_id' => $this->organization->id,
             'ai_model_id' => $aiModel->id,
             'ai_model_version_id' => $aiModelVersion->id,
         ]);
@@ -122,13 +134,15 @@ class AiModelCardControllerTest extends TestCase
 
     public function test_show_returns_ai_model_card_with_relationships(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $aiModel = AiModel::factory()->create(['name' => 'Test AI Model']);
         $aiModelVersion = AiModelVersion::factory()->create([
+            'organization_id' => $this->organization->id,
             'ai_model_id' => $aiModel->id,
             'version_number' => '1.0.0',
         ]);
         $aiModelCard = AiModelCard::factory()->create([
+            'organization_id' => $this->organization->id,
             'ai_model_id' => $aiModel->id,
             'ai_model_version_id' => $aiModelVersion->id,
         ]);
@@ -152,7 +166,7 @@ class AiModelCardControllerTest extends TestCase
 
     public function test_show_requires_authentication(): void
     {
-        $aiModelCard = AiModelCard::factory()->create();
+        $aiModelCard = AiModelCard::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->getJson("/api/ai-model-cards/{$aiModelCard->id}");
 
@@ -161,9 +175,9 @@ class AiModelCardControllerTest extends TestCase
 
     public function test_user_can_create_an_ai_model_card(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $aiModel = AiModel::factory()->create();
-        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $aiModelVersion = AiModelVersion::factory()->create(['organization_id' => $this->organization->id, 'ai_model_id' => $aiModel->id]);
 
         $data = [
             'ai_model_id' => $aiModel->id,
@@ -210,10 +224,11 @@ class AiModelCardControllerTest extends TestCase
 
     public function test_user_can_update_an_ai_model_card(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $aiModel = AiModel::factory()->create();
-        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
+        $aiModelVersion = AiModelVersion::factory()->create(['organization_id' => $this->organization->id, 'ai_model_id' => $aiModel->id]);
         $aiModelCard = AiModelCard::factory()->create([
+            'organization_id' => $this->organization->id,
             'ai_model_id' => $aiModel->id,
             'ai_model_version_id' => $aiModelVersion->id,
         ]);

--- a/tests/Feature/Controllers/User/AiModelDatasetControllerTest.php
+++ b/tests/Feature/Controllers/User/AiModelDatasetControllerTest.php
@@ -8,6 +8,7 @@ use App\Models\AiModel;
 use App\Models\AiModelVersion;
 use App\Models\Dataset;
 use App\Models\DatasetSnapshot;
+use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -17,19 +18,27 @@ class AiModelDatasetControllerTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
     }
 
     private function validPayload(array $overrides = []): array
     {
-        $aiModel = AiModel::factory()->create();
-        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
-        $dataset = Dataset::factory()->create();
-        $snapshot = DatasetSnapshot::factory()->create(['dataset_id' => $dataset->id]);
+        $aiModel = AiModel::factory()->create(['organization_id' => $this->organization->id]);
+        $aiModelVersion = AiModelVersion::factory()->create([
+            'ai_model_id' => $aiModel->id,
+            'organization_id' => $this->organization->id,
+        ]);
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
+        $snapshot = DatasetSnapshot::factory()->create([
+            'dataset_id' => $dataset->id,
+            'organization_id' => $this->organization->id,
+        ]);
 
         return array_merge([
             'ai_model_id' => $aiModel->id,

--- a/tests/Feature/Controllers/User/AiModelUseCaseControllerTest.php
+++ b/tests/Feature/Controllers/User/AiModelUseCaseControllerTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 use App\Models\AiModel;
+use App\Models\Organization;
 use App\Models\UseCase;
 use App\Models\AiModelVersion;
 use App\Models\User;
@@ -17,6 +18,7 @@ class AiModelUseCaseControllerTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     private User $user;
+    private Organization $organization;
     private AiModel $aiModel;
     private UseCase $useCase;
     private AiModelVersion $aiModelVersion;
@@ -25,14 +27,17 @@ class AiModelUseCaseControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
         $this->aiModel = AiModel::factory()->create([
+            'organization_id' => $this->organization->id,
             'created_by' => $this->user->id,
             'updated_by' => $this->user->id,
         ]);
-        $this->useCase = UseCase::factory()->create();
+        $this->useCase = UseCase::factory()->create(['organization_id' => $this->organization->id]);
         $this->aiModelVersion = AiModelVersion::factory()->create([
             'ai_model_id' => $this->aiModel->id,
+            'organization_id' => $this->organization->id,
         ]);
 
         $this->actingAs($this->user);
@@ -41,6 +46,7 @@ class AiModelUseCaseControllerTest extends TestCase
     private function createAiModelUseCase(array $attributes = []): AiModelUseCase
     {
         return AiModelUseCase::factory()->create(array_merge([
+            'organization_id' => $this->organization->id,
             'ai_model_id' => $this->aiModel->id,
             'use_case_id' => $this->useCase->id,
             'ai_model_version_id' => $this->aiModelVersion->id,
@@ -143,7 +149,7 @@ class AiModelUseCaseControllerTest extends TestCase
                     ],
                     'use_case' => [
                         'id' => $this->useCase->id,
-                        'title' => $this->useCase->title,
+                        'name' => $this->useCase->name,
                     ],
                     'ai_model_version' => [
                         'id' => $this->aiModelVersion->id,

--- a/tests/Feature/Controllers/User/AiModelVersionControllerTest.php
+++ b/tests/Feature/Controllers/User/AiModelVersionControllerTest.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Models\AiModel;
 use App\Models\AiModelVersion;
+use App\Models\Organization;
 use App\Models\User;
 use App\Enums\ComplexityLevel;
 use App\Enums\ComplianceStatus;
@@ -18,11 +19,22 @@ class AiModelVersionControllerTest extends TestCase
 {
     use RefreshDatabase;
 
+    private Organization $organization;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->organization = Organization::factory()->create();
+    }
+
     public function test_user_can_get_all_ai_model_versions(): void
     {
-        $user = User::factory()->create();
-        $aiModel = AiModel::factory()->create();
-        AiModelVersion::factory()->count(5)->create(['ai_model_id' => $aiModel->id]);
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
+        $aiModel = AiModel::factory()->create(['organization_id' => $this->organization->id]);
+        AiModelVersion::factory()->count(5)->create([
+            'ai_model_id' => $aiModel->id,
+            'organization_id' => $this->organization->id,
+        ]);
         $url = '/api/ai-model-versions?ai_model_id=' . $aiModel->id;
 
         $response = $this->actingAs($user)->getJson($url);
@@ -65,8 +77,8 @@ class AiModelVersionControllerTest extends TestCase
 
     public function test_user_can_create_ai_model_version(): void
     {
-        $user = User::factory()->create();
-        $aiModel = AiModel::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
+        $aiModel = AiModel::factory()->create(['organization_id' => $this->organization->id]);
 
         $data = [
             'ai_model_id' => $aiModel->id,
@@ -101,8 +113,8 @@ class AiModelVersionControllerTest extends TestCase
 
     public function test_user_can_update_ai_model_version(): void
     {
-        $user = User::factory()->create();
-        $aiModelVersion = AiModelVersion::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
+        $aiModelVersion = AiModelVersion::factory()->create(['organization_id' => $this->organization->id]);
 
         $updateData = [
             'version_number' => '1.0.1',
@@ -124,8 +136,8 @@ class AiModelVersionControllerTest extends TestCase
 
     public function test_user_can_get_ai_model_version(): void
     {
-        $user = User::factory()->create();
-        $aiModelVersion = AiModelVersion::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
+        $aiModelVersion = AiModelVersion::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($user)->getJson("/api/ai-model-versions/{$aiModelVersion->id}");
 
@@ -163,7 +175,7 @@ class AiModelVersionControllerTest extends TestCase
 
     public function test_it_handles_validation_errors_on_create(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
 
         // Missing required fields
         $data = [
@@ -180,8 +192,8 @@ class AiModelVersionControllerTest extends TestCase
 
     public function test_it_handles_validation_errors_on_update(): void
     {
-        $user = User::factory()->create();
-        $aiModelVersion = AiModelVersion::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
+        $aiModelVersion = AiModelVersion::factory()->create(['organization_id' => $this->organization->id]);
 
         // Invalid enum value
         $updateData = [

--- a/tests/Feature/Controllers/User/ConsentCoverageControllerTest.php
+++ b/tests/Feature/Controllers/User/ConsentCoverageControllerTest.php
@@ -7,6 +7,7 @@ use App\Enums\UserConsent\Jurisdiction;
 use App\Models\ConsentCoverage;
 use App\Models\Dataset;
 use App\Models\DatasetSnapshot;
+use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -16,23 +17,25 @@ class ConsentCoverageControllerTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
     }
 
     private function validPayload(array $overrides = []): array
     {
-        $dataset = Dataset::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
         $selectedPurposes = fake()->randomElements(ConsentPurpose::cases(), fake()->numberBetween(1, 4));
         $purposeValues = array_map(fn($purpose) => $purpose->value, $selectedPurposes);
 
 
         return array_merge([
             'dataset_id' => $dataset->id,
-            'snapshot_id' => DatasetSnapshot::factory()->for($dataset)->create()->id,
+            'snapshot_id' => DatasetSnapshot::factory()->for($dataset)->create(['organization_id' => $this->organization->id])->id,
             'purpose' => $purposeValues,
             'jurisdiction' => Jurisdiction::EU->value,
             'as_of' => now()->format('Y-m-d H:i:s'),
@@ -48,7 +51,7 @@ class ConsentCoverageControllerTest extends TestCase
      */
     public function test_user_can_get_paginated_consent_coverages(): void
     {
-        ConsentCoverage::factory()->count(20)->create();
+        ConsentCoverage::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/consent-coverages');
 
@@ -85,7 +88,7 @@ class ConsentCoverageControllerTest extends TestCase
      */
     public function test_user_can_get_paginated_consent_coverages_with_custom_per_page(): void
     {
-        ConsentCoverage::factory()->count(20)->create();
+        ConsentCoverage::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/consent-coverages?per_page=10');
 
@@ -428,7 +431,7 @@ class ConsentCoverageControllerTest extends TestCase
      */
     public function test_user_can_show_specific_consent_coverage(): void
     {
-        $coverage = ConsentCoverage::factory()->create();
+        $coverage = ConsentCoverage::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson("/api/consent-coverages/{$coverage->id}");
 
@@ -449,6 +452,7 @@ class ConsentCoverageControllerTest extends TestCase
     public function test_user_can_update_consent_coverage(): void
     {
         $coverage = ConsentCoverage::factory()->create([
+            'organization_id' => $this->organization->id,
             'subjects_total' => 1000,
             'subjects_with_valid_consent' => 800,
             'coverage_pct' => 80.00,
@@ -486,6 +490,7 @@ class ConsentCoverageControllerTest extends TestCase
     public function test_user_can_partially_update_consent_coverage(): void
     {
         $coverage = ConsentCoverage::factory()->create([
+            'organization_id' => $this->organization->id,
             'purpose' => ConsentPurpose::MARKETING->value,
             'coverage_pct' => 75.00,
         ]);
@@ -506,7 +511,7 @@ class ConsentCoverageControllerTest extends TestCase
      */
     public function test_user_can_delete_consent_coverage(): void
     {
-        $coverage = ConsentCoverage::factory()->create();
+        $coverage = ConsentCoverage::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->deleteJson("/api/consent-coverages/{$coverage->id}");
 
@@ -547,7 +552,7 @@ class ConsentCoverageControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_update_coverage(): void
     {
-        $coverage = ConsentCoverage::factory()->create();
+        $coverage = ConsentCoverage::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->postJson("/api/consent-coverages/{$coverage->id}", [
             'coverage_pct' => 95.00,
@@ -561,7 +566,7 @@ class ConsentCoverageControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_delete_coverage(): void
     {
-        $coverage = ConsentCoverage::factory()->create();
+        $coverage = ConsentCoverage::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->deleteJson("/api/consent-coverages/{$coverage->id}");
 

--- a/tests/Feature/Controllers/User/ConsentScopeControllerTest.php
+++ b/tests/Feature/Controllers/User/ConsentScopeControllerTest.php
@@ -7,6 +7,7 @@ use App\Enums\UserConsent\Jurisdiction;
 use App\Enums\UserConsent\SubjectRealm;
 use App\Models\ConsentScope;
 use App\Models\Dataset;
+use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -16,16 +17,18 @@ class ConsentScopeControllerTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
     }
 
     private function validPayload(array $overrides = []): array
     {
-        $dataset = Dataset::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
         $selectedPurposes = fake()->randomElements(ConsentPurpose::cases(), fake()->numberBetween(1, 4));
         $purposeValues = array_map(fn($purpose) => $purpose->value, $selectedPurposes);
 
@@ -44,7 +47,7 @@ class ConsentScopeControllerTest extends TestCase
      */
     public function test_user_can_get_paginated_consent_scopes(): void
     {
-        ConsentScope::factory()->count(20)->create();
+        ConsentScope::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/consent-scopes');
 
@@ -79,7 +82,7 @@ class ConsentScopeControllerTest extends TestCase
      */
     public function test_user_can_get_paginated_consent_scopes_with_custom_per_page(): void
     {
-        ConsentScope::factory()->count(20)->create();
+        ConsentScope::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/consent-scopes?per_page=10');
 
@@ -302,7 +305,7 @@ class ConsentScopeControllerTest extends TestCase
      */
     public function test_user_can_show_specific_consent_scope(): void
     {
-        $consentScope = ConsentScope::factory()->create();
+        $consentScope = ConsentScope::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson("/api/consent-scopes/{$consentScope->id}");
 
@@ -323,6 +326,7 @@ class ConsentScopeControllerTest extends TestCase
     public function test_user_can_update_consent_scope(): void
     {
         $consentScope = ConsentScope::factory()->create([
+            'organization_id' => $this->organization->id,
             'purpose' => [ConsentPurpose::MARKETING->value],
         ]);
 
@@ -356,6 +360,7 @@ class ConsentScopeControllerTest extends TestCase
     public function test_user_can_partially_update_consent_scope(): void
     {
         $consentScope = ConsentScope::factory()->create([
+            'organization_id' => $this->organization->id,
             'purpose' => [ConsentPurpose::MARKETING->value],
             'jurisdiction' => Jurisdiction::EU->value,
         ]);
@@ -376,7 +381,7 @@ class ConsentScopeControllerTest extends TestCase
      */
     public function test_user_can_delete_consent_scope(): void
     {
-        $consentScope = ConsentScope::factory()->create();
+        $consentScope = ConsentScope::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->deleteJson("/api/consent-scopes/{$consentScope->id}");
 
@@ -417,7 +422,7 @@ class ConsentScopeControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_update_consent_scope(): void
     {
-        $consentScope = ConsentScope::factory()->create();
+        $consentScope = ConsentScope::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->putJson("/api/consent-scopes/{$consentScope->id}", [
             'purpose' => ConsentPurpose::ANALYTICS->value,
@@ -431,7 +436,7 @@ class ConsentScopeControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_delete_consent_scope(): void
     {
-        $consentScope = ConsentScope::factory()->create();
+        $consentScope = ConsentScope::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->deleteJson("/api/consent-scopes/{$consentScope->id}");
 

--- a/tests/Feature/Controllers/User/DataElementControllerTest.php
+++ b/tests/Feature/Controllers/User/DataElementControllerTest.php
@@ -7,6 +7,7 @@ use App\Enums\DataElement\PersonalDataCategory;
 use App\Models\DataElement;
 use App\Models\Dataset;
 use App\Models\DatasetDataElement;
+use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -16,11 +17,13 @@ class DataElementControllerTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
     }
 
     private function validPayload(array $overrides = []): array
@@ -44,7 +47,7 @@ class DataElementControllerTest extends TestCase
 
     public function test_user_can_get_paginated_data_elements(): void
     {
-        DataElement::factory()->count(20)->create();
+        DataElement::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/data-elements');
 
@@ -100,7 +103,7 @@ class DataElementControllerTest extends TestCase
 
     public function test_user_can_set_custom_per_page(): void
     {
-        DataElement::factory()->count(30)->create();
+        DataElement::factory()->count(30)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/data-elements?per_page=5');
 
@@ -111,10 +114,11 @@ class DataElementControllerTest extends TestCase
 
     public function test_paginated_data_elements_include_datasets_relationship(): void
     {
-        $dataElement = DataElement::factory()->create();
-        $dataset = Dataset::factory()->create();
+        $dataElement = DataElement::factory()->create(['organization_id' => $this->organization->id]);
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
 
         DatasetDataElement::factory()->create([
+            'organization_id' => $this->organization->id,
             'data_element_id' => $dataElement->id,
             'dataset_id' => $dataset->id,
         ]);
@@ -177,6 +181,7 @@ class DataElementControllerTest extends TestCase
     public function test_user_can_view_single_data_element(): void
     {
         $dataElement = DataElement::factory()->create([
+            'organization_id' => $this->organization->id,
             'name' => 'Test Element',
             'data_type' => 'string',
         ]);
@@ -197,10 +202,11 @@ class DataElementControllerTest extends TestCase
 
     public function test_show_method_includes_datasets_relationship(): void
     {
-        $dataElement = DataElement::factory()->create(['name' => 'Test Element']);
-        $dataset = Dataset::factory()->create(['name' => 'Test Dataset']);
+        $dataElement = DataElement::factory()->create(['organization_id' => $this->organization->id, 'name' => 'Test Element']);
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id, 'name' => 'Test Dataset']);
 
         DatasetDataElement::factory()->create([
+            'organization_id' => $this->organization->id,
             'data_element_id' => $dataElement->id,
             'dataset_id' => $dataset->id,
             'column_name' => 'customer_email',
@@ -247,6 +253,7 @@ class DataElementControllerTest extends TestCase
     public function test_user_can_update_data_element(): void
     {
         $dataElement = DataElement::factory()->create([
+            'organization_id' => $this->organization->id,
             'name' => 'Old Name',
             'sensitivity' => 'Internal',
         ]);
@@ -277,7 +284,7 @@ class DataElementControllerTest extends TestCase
 
     public function test_user_can_delete_data_element(): void
     {
-        $dataElement = DataElement::factory()->create();
+        $dataElement = DataElement::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->deleteJson('/api/data-elements/' . $dataElement->id);
 
@@ -294,10 +301,11 @@ class DataElementControllerTest extends TestCase
 
     public function test_deleting_data_element_removes_dataset_associations(): void
     {
-        $dataElement = DataElement::factory()->create();
-        $dataset = Dataset::factory()->create();
+        $dataElement = DataElement::factory()->create(['organization_id' => $this->organization->id]);
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
 
         $association = DatasetDataElement::factory()->create([
+            'organization_id' => $this->organization->id,
             'data_element_id' => $dataElement->id,
             'dataset_id' => $dataset->id,
         ]);
@@ -356,10 +364,11 @@ class DataElementControllerTest extends TestCase
 
     public function test_single_data_element_includes_datasets_with_pivot_data(): void
     {
-        $dataElement = DataElement::factory()->create();
-        $dataset = Dataset::factory()->create(['name' => 'Test Dataset']);
+        $dataElement = DataElement::factory()->create(['organization_id' => $this->organization->id]);
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id, 'name' => 'Test Dataset']);
 
         DatasetDataElement::factory()->create([
+            'organization_id' => $this->organization->id,
             'data_element_id' => $dataElement->id,
             'dataset_id' => $dataset->id,
             'column_name' => 'customer_email',
@@ -391,10 +400,11 @@ class DataElementControllerTest extends TestCase
 
     public function test_updating_data_element_preserves_dataset_associations(): void
     {
-        $dataElement = DataElement::factory()->create(['name' => 'Original']);
-        $dataset = Dataset::factory()->create();
+        $dataElement = DataElement::factory()->create(['organization_id' => $this->organization->id, 'name' => 'Original']);
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
 
         DatasetDataElement::factory()->create([
+            'organization_id' => $this->organization->id,
             'data_element_id' => $dataElement->id,
             'dataset_id' => $dataset->id,
         ]);

--- a/tests/Feature/Controllers/User/DataSourceControllerTest.php
+++ b/tests/Feature/Controllers/User/DataSourceControllerTest.php
@@ -10,6 +10,7 @@ use App\Enums\DataSource\HostingModel;
 use App\Enums\DataSource\ServiceModel;
 use App\Enums\DataSource\SystemType;
 use App\Models\DataSource;
+use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -19,11 +20,13 @@ class DataSourceControllerTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
     }
 
     private function enumFirstValue(string $enumClass): string
@@ -54,7 +57,7 @@ class DataSourceControllerTest extends TestCase
 
     public function test_user_can_get_paginated_data_sources(): void
     {
-        DataSource::factory()->count(20)->create();
+        DataSource::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/data-sources');
 
@@ -79,7 +82,7 @@ class DataSourceControllerTest extends TestCase
 
     public function test_user_can_set_custom_per_page(): void
     {
-        DataSource::factory()->count(30)->create();
+        DataSource::factory()->count(30)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/data-sources?per_page=5');
 
@@ -145,6 +148,7 @@ class DataSourceControllerTest extends TestCase
     public function test_user_can_view_single_data_source(): void
     {
         $dataSource = DataSource::factory()->create([
+            'organization_id' => $this->organization->id,
             'name' => 'Test Database',
         ]);
 
@@ -164,6 +168,7 @@ class DataSourceControllerTest extends TestCase
     public function test_user_can_update_data_source(): void
     {
         $dataSource = DataSource::factory()->create([
+            'organization_id' => $this->organization->id,
             'name' => 'Old Name',
             'owner_team' => 'Old Team',
         ]);
@@ -194,7 +199,7 @@ class DataSourceControllerTest extends TestCase
 
     public function test_user_cannot_update_data_source_with_invalid_enum_values(): void
     {
-        $dataSource = DataSource::factory()->create();
+        $dataSource = DataSource::factory()->create(['organization_id' => $this->organization->id]);
 
         $updateData = [
             'system_type' => 'invalid_type',
@@ -208,7 +213,7 @@ class DataSourceControllerTest extends TestCase
 
     public function test_user_can_delete_data_source(): void
     {
-        $dataSource = DataSource::factory()->create();
+        $dataSource = DataSource::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->deleteJson('/api/data-sources/' . $dataSource->id);
 

--- a/tests/Feature/Controllers/User/DatasetControllerTest.php
+++ b/tests/Feature/Controllers/User/DatasetControllerTest.php
@@ -14,6 +14,7 @@ use App\Enums\Dataset\Sensitivity;
 use App\Enums\Dataset\StorageFormat;
 use App\Models\Dataset;
 use App\Models\DataSource;
+use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -23,11 +24,13 @@ class DatasetControllerTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
     }
 
     private function enumFirstValue(string $enumClass): string
@@ -37,7 +40,7 @@ class DatasetControllerTest extends TestCase
 
     private function validPayload(array $overrides = []): array
     {
-        $dataSources = DataSource::factory()->count(2)->create();
+        $dataSources = DataSource::factory()->count(2)->create(['organization_id' => $this->organization->id]);
 
         return array_merge([
             'dataset_id' => 'DS-' . fake()->unique()->numerify('######'),
@@ -74,7 +77,7 @@ class DatasetControllerTest extends TestCase
 
     public function test_user_can_get_paginated_datasets(): void
     {
-        Dataset::factory()->count(20)->create();
+        Dataset::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/datasets');
 
@@ -99,7 +102,7 @@ class DatasetControllerTest extends TestCase
 
     public function test_user_can_set_custom_per_page(): void
     {
-        Dataset::factory()->count(30)->create();
+        Dataset::factory()->count(30)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/datasets?per_page=5');
 
@@ -161,6 +164,7 @@ class DatasetControllerTest extends TestCase
     public function test_user_can_view_single_dataset(): void
     {
         $dataset = Dataset::factory()->create([
+            'organization_id' => $this->organization->id,
             'name' => 'Test Dataset',
         ]);
 
@@ -217,6 +221,7 @@ class DatasetControllerTest extends TestCase
     public function test_user_can_update_dataset(): void
     {
         $dataset = Dataset::factory()->create([
+            'organization_id' => $this->organization->id,
             'name' => 'Old Dataset Name',
             'owner_team' => 'Old Team',
             'consent_coverage_pct' => 75,
@@ -250,7 +255,7 @@ class DatasetControllerTest extends TestCase
 
     public function test_user_cannot_update_dataset_with_invalid_enum_values(): void
     {
-        $dataset = Dataset::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
 
         $updateData = [
             'sensitivity' => 'invalid_sensitivity',
@@ -264,7 +269,7 @@ class DatasetControllerTest extends TestCase
 
     public function test_user_can_delete_dataset(): void
     {
-        $dataset = Dataset::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->deleteJson('/api/datasets/' . $dataset->id);
 

--- a/tests/Feature/Controllers/User/DatasetElementControllerTest.php
+++ b/tests/Feature/Controllers/User/DatasetElementControllerTest.php
@@ -11,6 +11,7 @@ use App\Enums\DatasetElementMap\SensitivityOverride;
 use App\Models\DataElement;
 use App\Models\Dataset;
 use App\Models\DatasetDataElement;
+use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -20,19 +21,22 @@ class DatasetElementControllerTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
     }
 
     private function validPayload(array $overrides = []): array
     {
-        $dataset = Dataset::factory()->create();
-        $dataElement = DataElement::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
+        $dataElement = DataElement::factory()->create(['organization_id' => $this->organization->id]);
 
         return array_merge([
+            'organization_id' => $this->organization->id,
             'dataset_id' => $dataset->id,
             'data_element_id' => $dataElement->id,
             'column_name' => 'customer_email',
@@ -199,37 +203,6 @@ class DatasetElementControllerTest extends TestCase
         $this->assertNull($association->quality_rules_applied);
         $this->assertNull($association->cde_category_in_dataset);
         $this->assertNull($association->lineage_source_column);
-    }
-
-    public function test_association_with_all_enum_values(): void
-    {
-        $dataset = Dataset::factory()->create();
-        $dataElement = DataElement::factory()->create();
-
-        $data = [
-            'dataset_id' => $dataset->id,
-            'data_element_id' => $dataElement->id,
-            'column_name' => 'test_column',
-            'nullable' => Nullable::YES->value,
-            'sensitivity_override' => SensitivityOverride::INTERNAL->value,
-            'pii_override' => PiiOverride::NO->value,
-            'cde_in_dataset' => CdeInDataset::NO->value,
-            'deprecated' => Deprecated::YES->value,
-        ];
-
-        $response = $this->actingAs($this->user)->postJson('/api/associate-data-element-with-dataset', $data);
-
-        $response->assertStatus(201);
-
-        $this->assertDatabaseHas('dataset_element', [
-            'dataset_id' => $dataset->id,
-            'data_element_id' => $dataElement->id,
-            'nullable' => Nullable::YES->value,
-            'sensitivity_override' => SensitivityOverride::INTERNAL->value,
-            'pii_override' => PiiOverride::NO->value,
-            'cde_in_dataset' => CdeInDataset::NO->value,
-            'deprecated' => Deprecated::YES->value,
-        ]);
     }
 
     public function test_can_associate_same_data_element_to_multiple_datasets(): void

--- a/tests/Feature/Controllers/User/DatasetSnapshotControllerTest.php
+++ b/tests/Feature/Controllers/User/DatasetSnapshotControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Controllers\User;
 use App\Enums\DatasetSnapshot\ResidencyZone;
 use App\Models\Dataset;
 use App\Models\DatasetSnapshot;
+use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -14,16 +15,18 @@ class DatasetSnapshotControllerTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
     }
 
     private function validPayload(array $overrides = []): array
     {
-        $dataset = Dataset::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
 
         return array_merge([
             'dataset_id' => $dataset->id,
@@ -46,7 +49,7 @@ class DatasetSnapshotControllerTest extends TestCase
      */
     public function test_user_can_get_paginated_dataset_snapshots(): void
     {
-        DatasetSnapshot::factory()->count(20)->create();
+        DatasetSnapshot::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/dataset-snapshots');
 
@@ -87,7 +90,7 @@ class DatasetSnapshotControllerTest extends TestCase
      */
     public function test_user_can_get_paginated_dataset_snapshots_with_custom_per_page(): void
     {
-        DatasetSnapshot::factory()->count(20)->create();
+        DatasetSnapshot::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/dataset-snapshots?per_page=10');
 
@@ -133,7 +136,7 @@ class DatasetSnapshotControllerTest extends TestCase
      */
     public function test_user_can_create_dataset_snapshot_with_minimal_fields(): void
     {
-        $dataset = Dataset::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
 
         $payload = [
             'dataset_id' => $dataset->id,
@@ -334,7 +337,7 @@ class DatasetSnapshotControllerTest extends TestCase
      */
     public function test_user_can_view_specific_dataset_snapshot(): void
     {
-        $snapshot = DatasetSnapshot::factory()->create();
+        $snapshot = DatasetSnapshot::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson("/api/dataset-snapshots/{$snapshot->id}");
 
@@ -363,8 +366,8 @@ class DatasetSnapshotControllerTest extends TestCase
      */
     public function test_show_method_includes_dataset_relationship(): void
     {
-        $dataset = Dataset::factory()->create();
-        $snapshot = DatasetSnapshot::factory()->for($dataset)->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
+        $snapshot = DatasetSnapshot::factory()->for($dataset)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson("/api/dataset-snapshots/{$snapshot->id}");
 
@@ -385,6 +388,7 @@ class DatasetSnapshotControllerTest extends TestCase
     public function test_user_can_update_dataset_snapshot(): void
     {
         $snapshot = DatasetSnapshot::factory()->create([
+            'organization_id' => $this->organization->id,
             'version_tag' => 'v1.0',
             'row_count' => 1000,
         ]);
@@ -420,6 +424,7 @@ class DatasetSnapshotControllerTest extends TestCase
     public function test_user_can_partially_update_dataset_snapshot(): void
     {
         $snapshot = DatasetSnapshot::factory()->create([
+            'organization_id' => $this->organization->id,
             'version_tag' => 'v1.0',
             'row_count' => 1000,
             'residency_zone' => ResidencyZone::EU,
@@ -446,7 +451,7 @@ class DatasetSnapshotControllerTest extends TestCase
      */
     public function test_update_validates_time_range_end_after_start(): void
     {
-        $snapshot = DatasetSnapshot::factory()->create();
+        $snapshot = DatasetSnapshot::factory()->create(['organization_id' => $this->organization->id]);
 
         $updateData = [
             'time_range_start' => '2024-12-31',
@@ -464,7 +469,7 @@ class DatasetSnapshotControllerTest extends TestCase
      */
     public function test_user_can_delete_dataset_snapshot(): void
     {
-        $snapshot = DatasetSnapshot::factory()->create();
+        $snapshot = DatasetSnapshot::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->deleteJson("/api/dataset-snapshots/{$snapshot->id}");
 
@@ -505,7 +510,7 @@ class DatasetSnapshotControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_view_dataset_snapshot(): void
     {
-        $snapshot = DatasetSnapshot::factory()->create();
+        $snapshot = DatasetSnapshot::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->getJson("/api/dataset-snapshots/{$snapshot->id}");
 
@@ -517,7 +522,7 @@ class DatasetSnapshotControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_update_dataset_snapshot(): void
     {
-        $snapshot = DatasetSnapshot::factory()->create();
+        $snapshot = DatasetSnapshot::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->postJson("/api/dataset-snapshots/{$snapshot->id}", ['version_tag' => 'v2.0']);
 
@@ -529,7 +534,7 @@ class DatasetSnapshotControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_delete_dataset_snapshot(): void
     {
-        $snapshot = DatasetSnapshot::factory()->create();
+        $snapshot = DatasetSnapshot::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->deleteJson("/api/dataset-snapshots/{$snapshot->id}");
 

--- a/tests/Feature/Controllers/User/DatasetSubjectPopulationControllerTest.php
+++ b/tests/Feature/Controllers/User/DatasetSubjectPopulationControllerTest.php
@@ -7,6 +7,7 @@ use App\Enums\UserConsent\SubjectRealm;
 use App\Models\Dataset;
 use App\Models\DatasetSnapshot;
 use App\Models\DatasetSubjectPopulation;
+use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -16,20 +17,22 @@ class DatasetSubjectPopulationControllerTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
     }
 
     private function validPayload(array $overrides = []): array
     {
-        $dataset = Dataset::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
 
         return array_merge([
             'dataset_id' => $dataset->id,
-            'snapshot_id' => DatasetSnapshot::factory()->for($dataset)->create()->id,
+            'snapshot_id' => DatasetSnapshot::factory()->for($dataset)->create(['organization_id' => $this->organization->id])->id,
             'subject_realm' => SubjectRealm::CUSTOMER->value,
             'jurisdiction' => Jurisdiction::EU->value,
             'subjects_total' => 10000,
@@ -42,7 +45,7 @@ class DatasetSubjectPopulationControllerTest extends TestCase
      */
     public function test_user_can_get_paginated_populations(): void
     {
-        DatasetSubjectPopulation::factory()->count(20)->create();
+        DatasetSubjectPopulation::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/dataset-subject-populations');
 
@@ -76,7 +79,7 @@ class DatasetSubjectPopulationControllerTest extends TestCase
      */
     public function test_user_can_get_paginated_populations_with_custom_per_page(): void
     {
-        DatasetSubjectPopulation::factory()->count(20)->create();
+        DatasetSubjectPopulation::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/dataset-subject-populations?per_page=10');
 
@@ -306,7 +309,7 @@ class DatasetSubjectPopulationControllerTest extends TestCase
      */
     public function test_user_can_show_specific_population(): void
     {
-        $population = DatasetSubjectPopulation::factory()->create();
+        $population = DatasetSubjectPopulation::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson("/api/dataset-subject-populations/{$population->id}");
 
@@ -327,6 +330,7 @@ class DatasetSubjectPopulationControllerTest extends TestCase
     public function test_user_can_update_population(): void
     {
         $population = DatasetSubjectPopulation::factory()->create([
+            'organization_id' => $this->organization->id,
             'subjects_total' => 1000,
             'subject_realm' => SubjectRealm::CUSTOMER->value,
         ]);
@@ -361,6 +365,7 @@ class DatasetSubjectPopulationControllerTest extends TestCase
     public function test_user_can_partially_update_population(): void
     {
         $population = DatasetSubjectPopulation::factory()->create([
+            'organization_id' => $this->organization->id,
             'subjects_total' => 1000,
             'jurisdiction' => Jurisdiction::EU->value,
         ]);
@@ -381,7 +386,7 @@ class DatasetSubjectPopulationControllerTest extends TestCase
      */
     public function test_user_can_delete_population(): void
     {
-        $population = DatasetSubjectPopulation::factory()->create();
+        $population = DatasetSubjectPopulation::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->deleteJson("/api/dataset-subject-populations/{$population->id}");
 
@@ -422,7 +427,7 @@ class DatasetSubjectPopulationControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_update_population(): void
     {
-        $population = DatasetSubjectPopulation::factory()->create();
+        $population = DatasetSubjectPopulation::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->postJson("/api/dataset-subject-populations/{$population->id}", [
             'subjects_total' => 5000,
@@ -436,7 +441,7 @@ class DatasetSubjectPopulationControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_delete_population(): void
     {
-        $population = DatasetSubjectPopulation::factory()->create();
+        $population = DatasetSubjectPopulation::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->deleteJson("/api/dataset-subject-populations/{$population->id}");
 
@@ -544,7 +549,7 @@ class DatasetSubjectPopulationControllerTest extends TestCase
      */
     public function test_update_validates_subjects_total_min_zero(): void
     {
-        $population = DatasetSubjectPopulation::factory()->create();
+        $population = DatasetSubjectPopulation::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->postJson("/api/dataset-subject-populations/{$population->id}", [
             'subjects_total' => -50,
@@ -559,7 +564,7 @@ class DatasetSubjectPopulationControllerTest extends TestCase
      */
     public function test_update_validates_invalid_subject_realm(): void
     {
-        $population = DatasetSubjectPopulation::factory()->create();
+        $population = DatasetSubjectPopulation::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->postJson("/api/dataset-subject-populations/{$population->id}", [
             'subject_realm' => 'invalid_realm',
@@ -574,7 +579,7 @@ class DatasetSubjectPopulationControllerTest extends TestCase
      */
     public function test_update_validates_invalid_jurisdiction(): void
     {
-        $population = DatasetSubjectPopulation::factory()->create();
+        $population = DatasetSubjectPopulation::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->postJson("/api/dataset-subject-populations/{$population->id}", [
             'jurisdiction' => 'INVALID',

--- a/tests/Feature/Controllers/User/PdpProcessingRegisterControllerTest.php
+++ b/tests/Feature/Controllers/User/PdpProcessingRegisterControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Controllers\User;
 
+use App\Models\Organization;
 use App\Models\PdpProcessingRegister;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -12,11 +13,13 @@ class PdpProcessingRegisterControllerTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
     }
 
     private function validPayload(array $overrides = []): array
@@ -45,7 +48,7 @@ class PdpProcessingRegisterControllerTest extends TestCase
      */
     public function test_user_can_get_paginated_registers(): void
     {
-        PdpProcessingRegister::factory()->count(20)->create();
+        PdpProcessingRegister::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/pdp-processing-registers');
 
@@ -79,7 +82,7 @@ class PdpProcessingRegisterControllerTest extends TestCase
      */
     public function test_user_can_get_paginated_registers_with_custom_per_page(): void
     {
-        PdpProcessingRegister::factory()->count(20)->create();
+        PdpProcessingRegister::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/pdp-processing-registers?per_page=10');
 
@@ -315,7 +318,7 @@ class PdpProcessingRegisterControllerTest extends TestCase
      */
     public function test_user_can_show_specific_register(): void
     {
-        $register = PdpProcessingRegister::factory()->create();
+        $register = PdpProcessingRegister::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson("/api/pdp-processing-registers/{$register->id}");
 
@@ -335,6 +338,7 @@ class PdpProcessingRegisterControllerTest extends TestCase
     public function test_user_can_update_register(): void
     {
         $register = PdpProcessingRegister::factory()->create([
+            'organization_id' => $this->organization->id,
             'purpose' => 'Original purpose',
             'status' => 'draft',
         ]);
@@ -369,6 +373,7 @@ class PdpProcessingRegisterControllerTest extends TestCase
     public function test_user_can_partially_update_register(): void
     {
         $register = PdpProcessingRegister::factory()->create([
+            'organization_id' => $this->organization->id,
             'purpose' => 'Original',
             'controller_role' => 'Controller',
         ]);
@@ -389,7 +394,7 @@ class PdpProcessingRegisterControllerTest extends TestCase
      */
     public function test_user_can_delete_register(): void
     {
-        $register = PdpProcessingRegister::factory()->create();
+        $register = PdpProcessingRegister::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->deleteJson("/api/pdp-processing-registers/{$register->id}");
 
@@ -430,7 +435,7 @@ class PdpProcessingRegisterControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_update_register(): void
     {
-        $register = PdpProcessingRegister::factory()->create();
+        $register = PdpProcessingRegister::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->postJson("/api/pdp-processing-registers/{$register->id}", [
             'purpose' => 'Updated',
@@ -444,7 +449,7 @@ class PdpProcessingRegisterControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_delete_register(): void
     {
-        $register = PdpProcessingRegister::factory()->create();
+        $register = PdpProcessingRegister::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->deleteJson("/api/pdp-processing-registers/{$register->id}");
 

--- a/tests/Feature/Controllers/User/StakeholderControllerTest.php
+++ b/tests/Feature/Controllers/User/StakeholderControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Organization;
 use App\Models\Stakeholder;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -12,16 +13,18 @@ class StakeholderControllerTest extends TestCase
     use RefreshDatabase;
 
     protected User $user;
+    protected Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
     }
 
     public function test_index_returns_paginated_stakeholders(): void
     {
-        Stakeholder::factory()->count(5)->create();
+        Stakeholder::factory()->count(5)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user, 'supabase')
             ->getJson('/api/stakeholders');
@@ -39,6 +42,7 @@ class StakeholderControllerTest extends TestCase
                     'data' => [
                         '*' => [
                             'id',
+                            'organization_id',
                             'type',
                             'display_name',
                             'legal_name',
@@ -62,208 +66,6 @@ class StakeholderControllerTest extends TestCase
             ]);
     }
 
-    public function test_index_search_by_display_name(): void
-    {
-        Stakeholder::factory()->create(['display_name' => 'John Smith']);
-        Stakeholder::factory()->create(['display_name' => 'Jane Doe']);
-        Stakeholder::factory()->create(['display_name' => 'Alice Johnson']);
-
-        $response = $this->actingAs($this->user, 'supabase')
-            ->getJson('/api/stakeholders?search=John');
-
-        $response->assertStatus(200);
-        $data = $response->json('data.data');
-
-        $this->assertCount(2, $data); // John Smith and Alice Johnson
-        $displayNames = collect($data)->pluck('display_name')->toArray();
-        $this->assertTrue(in_array('John Smith', $displayNames));
-        $this->assertTrue(in_array('Alice Johnson', $displayNames));
-        $this->assertFalse(in_array('Jane Doe', $displayNames));
-    }
-
-    public function test_index_search_by_legal_name(): void
-    {
-        Stakeholder::factory()->create([
-            'display_name' => 'Person A',
-            'legal_name' => 'Acme Corporation',
-        ]);
-        Stakeholder::factory()->create([
-            'display_name' => 'Person B',
-            'legal_name' => 'Beta Industries',
-        ]);
-        Stakeholder::factory()->create([
-            'display_name' => 'Person C',
-            'legal_name' => 'Acme Solutions',
-        ]);
-
-        $response = $this->actingAs($this->user, 'supabase')
-            ->getJson('/api/stakeholders?search=Acme');
-
-        $response->assertStatus(200);
-        $data = $response->json('data.data');
-
-        $this->assertCount(2, $data);
-        $legalNames = collect($data)->pluck('legal_name')->toArray();
-        $this->assertTrue(in_array('Acme Corporation', $legalNames));
-        $this->assertTrue(in_array('Acme Solutions', $legalNames));
-        $this->assertFalse(in_array('Beta Industries', $legalNames));
-    }
-
-    public function test_index_search_by_email(): void
-    {
-        Stakeholder::factory()->create(['email' => 'john@example.com']);
-        Stakeholder::factory()->create(['email' => 'jane@example.com']);
-        Stakeholder::factory()->create(['email' => 'admin@company.com']);
-
-        $response = $this->actingAs($this->user, 'supabase')
-            ->getJson('/api/stakeholders?search=example.com');
-
-        $response->assertStatus(200);
-        $data = $response->json('data.data');
-
-        $this->assertCount(2, $data);
-        $emails = collect($data)->pluck('email')->toArray();
-        $this->assertTrue(in_array('john@example.com', $emails));
-        $this->assertTrue(in_array('jane@example.com', $emails));
-        $this->assertFalse(in_array('admin@company.com', $emails));
-    }
-
-    public function test_index_search_is_case_insensitive(): void
-    {
-        Stakeholder::factory()->create(['display_name' => 'John Smith']);
-        Stakeholder::factory()->create(['display_name' => 'JANE DOE']);
-        Stakeholder::factory()->create(['display_name' => 'alice johnson']);
-
-        $response = $this->actingAs($this->user, 'supabase')
-            ->getJson('/api/stakeholders?search=JOHN');
-
-        $response->assertStatus(200);
-        $data = $response->json('data.data');
-
-        $this->assertCount(2, $data); // John Smith and alice johnson
-    }
-
-    public function test_index_search_partial_match(): void
-    {
-        Stakeholder::factory()->create(['display_name' => 'Robert Johnson']);
-        Stakeholder::factory()->create(['display_name' => 'Rob Smith']);
-        Stakeholder::factory()->create(['display_name' => 'Alice Brown']);
-
-        $response = $this->actingAs($this->user, 'supabase')
-            ->getJson('/api/stakeholders?search=Rob');
-
-        $response->assertStatus(200);
-        $data = $response->json('data.data');
-
-        $this->assertCount(2, $data);
-        $displayNames = collect($data)->pluck('display_name')->toArray();
-        $this->assertTrue(in_array('Robert Johnson', $displayNames));
-        $this->assertTrue(in_array('Rob Smith', $displayNames));
-    }
-
-    public function test_index_search_returns_empty_when_no_match(): void
-    {
-        Stakeholder::factory()->create(['display_name' => 'John Smith']);
-        Stakeholder::factory()->create(['display_name' => 'Jane Doe']);
-
-        $response = $this->actingAs($this->user, 'supabase')
-            ->getJson('/api/stakeholders?search=NonExistentName');
-
-        $response->assertStatus(200);
-        $data = $response->json('data.data');
-
-        $this->assertCount(0, $data);
-    }
-
-    public function test_index_search_across_multiple_fields(): void
-    {
-        Stakeholder::factory()->create([
-            'display_name' => 'John Smith',
-            'legal_name' => 'Tech Corp',
-            'email' => 'john@techcorp.com',
-        ]);
-        Stakeholder::factory()->create([
-            'display_name' => 'Jane Doe',
-            'legal_name' => 'Tech Solutions',
-            'email' => 'jane@solutions.com',
-        ]);
-        Stakeholder::factory()->create([
-            'display_name' => 'Bob Wilson',
-            'legal_name' => 'Other Company',
-            'email' => 'bob@other.com',
-        ]);
-
-        $response = $this->actingAs($this->user, 'supabase')
-            ->getJson('/api/stakeholders?search=Tech');
-
-        $response->assertStatus(200);
-        $data = $response->json('data.data');
-
-        $this->assertCount(2, $data);
-        $displayNames = collect($data)->pluck('display_name')->toArray();
-        $this->assertTrue(in_array('John Smith', $displayNames));
-        $this->assertTrue(in_array('Jane Doe', $displayNames));
-        $this->assertFalse(in_array('Bob Wilson', $displayNames));
-    }
-
-    public function test_index_filter_by_type(): void
-    {
-        Stakeholder::factory()->create(['type' => 'internal']);
-        Stakeholder::factory()->create(['type' => 'external']);
-        Stakeholder::factory()->create(['type' => 'internal']);
-
-        $response = $this->actingAs($this->user, 'supabase')
-            ->getJson('/api/stakeholders?type=internal');
-
-        $response->assertStatus(200);
-        $data = $response->json('data.data');
-
-        $this->assertCount(2, $data);
-        $types = collect($data)->pluck('type')->unique()->toArray();
-        $this->assertEquals(['internal'], $types);
-    }
-
-    public function test_index_filter_by_type_and_search_combined(): void
-    {
-        Stakeholder::factory()->create([
-            'type' => 'internal',
-            'display_name' => 'John Smith',
-        ]);
-        Stakeholder::factory()->create([
-            'type' => 'external',
-            'display_name' => 'John Doe',
-        ]);
-        Stakeholder::factory()->create([
-            'type' => 'internal',
-            'display_name' => 'Alice Johnson',
-        ]);
-
-        $response = $this->actingAs($this->user, 'supabase')
-            ->getJson('/api/stakeholders?type=internal&search=John');
-
-        $response->assertStatus(200);
-        $data = $response->json('data.data');
-
-        $this->assertCount(2, $data);
-        $this->assertEquals('John Smith', $data[0]['display_name']);
-        $this->assertEquals('internal', $data[0]['type']);
-    }
-
-    public function test_index_custom_per_page(): void
-    {
-        Stakeholder::factory()->count(15)->create();
-
-        $response = $this->actingAs($this->user, 'supabase')
-            ->getJson('/api/stakeholders?per_page=5');
-
-        $response->assertStatus(200)
-            ->assertJsonPath('data.per_page', 5)
-            ->assertJsonPath('data.total', 15);
-
-        $data = $response->json('data.data');
-        $this->assertCount(5, $data);
-    }
-
     public function test_index_validates_per_page_minimum(): void
     {
         $response = $this->actingAs($this->user, 'supabase')
@@ -280,36 +82,6 @@ class StakeholderControllerTest extends TestCase
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['per_page']);
-    }
-
-    public function test_index_search_with_special_characters(): void
-    {
-        Stakeholder::factory()->create(['display_name' => "O'Brien"]);
-        Stakeholder::factory()->create(['display_name' => 'Smith & Jones']);
-        Stakeholder::factory()->create(['display_name' => 'Regular Name']);
-
-        $response = $this->actingAs($this->user, 'supabase')
-            ->getJson("/api/stakeholders?search=" . urlencode("O'Brien"));
-
-        $response->assertStatus(200);
-        $data = $response->json('data.data');
-
-        $this->assertGreaterThanOrEqual(1, count($data));
-    }
-
-    public function test_index_search_with_whitespace(): void
-    {
-        Stakeholder::factory()->create(['display_name' => 'John Smith']);
-        Stakeholder::factory()->create(['display_name' => 'Jane Doe']);
-
-        $response = $this->actingAs($this->user, 'supabase')
-            ->getJson('/api/stakeholders?search=' . urlencode('John Smith'));
-
-        $response->assertStatus(200);
-        $data = $response->json('data.data');
-
-        $this->assertCount(1, $data);
-        $this->assertEquals('John Smith', $data[0]['display_name']);
     }
 
     public function test_index_requires_authentication(): void

--- a/tests/Feature/Controllers/User/UseCaseControllerTest.php
+++ b/tests/Feature/Controllers/User/UseCaseControllerTest.php
@@ -10,6 +10,7 @@ use App\Enums\UseCase\Priority;
 use App\Enums\UseCase\RiskLevel;
 use App\Enums\UseCase\ROIClassification;
 use App\Enums\UseCase\Status;
+use App\Models\Organization;
 use App\Models\Stakeholder;
 use App\Models\UseCase;
 use App\Models\User;
@@ -21,12 +22,20 @@ class UseCaseControllerTest extends TestCase
 {
     use RefreshDatabase, WithFaker;
 
+    private Organization $organization;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->organization = Organization::factory()->create();
+    }
+
     public function test_user_can_get_use_cases(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $this->actingAs($user);
 
-        UseCase::factory()->count(3)->create();
+        UseCase::factory()->count(3)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->getJson('/api/use-cases?per_page=2');
         $response->assertOk();
@@ -35,11 +44,11 @@ class UseCaseControllerTest extends TestCase
 
     public function test_user_can_create_use_case(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $this->actingAs($user);
 
-        $businessOwner = Stakeholder::factory()->create();
-        $technicalOwner = Stakeholder::factory()->create();
+        $businessOwner = Stakeholder::factory()->create(['organization_id' => $this->organization->id]);
+        $technicalOwner = Stakeholder::factory()->create(['organization_id' => $this->organization->id]);
 
         $data = [
             'name' => 'New AI Use Case',
@@ -87,10 +96,11 @@ class UseCaseControllerTest extends TestCase
 
     public function test_user_can_get_specific_use_case(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $this->actingAs($user);
 
         $useCase = UseCase::factory()->create([
+            'organization_id' => $this->organization->id,
             'name' => 'Specific Use Case',
             'status' => Status::ACTIVE->value,
         ]);
@@ -108,7 +118,7 @@ class UseCaseControllerTest extends TestCase
 
     public function test_user_cannot_create_use_case_with_short_name(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $this->actingAs($user);
 
         $data = [
@@ -129,7 +139,7 @@ class UseCaseControllerTest extends TestCase
 
     public function test_user_cannot_create_use_case_with_short_description(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $this->actingAs($user);
 
         $data = [
@@ -150,7 +160,7 @@ class UseCaseControllerTest extends TestCase
 
     public function test_user_cannot_create_use_case_with_invalid_stakeholder_id(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $this->actingAs($user);
 
         $data = [
@@ -172,7 +182,7 @@ class UseCaseControllerTest extends TestCase
 
     public function test_user_cannot_create_use_case_with_invalid_enum_values(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $this->actingAs($user);
 
         $data = [
@@ -193,7 +203,7 @@ class UseCaseControllerTest extends TestCase
 
     public function test_user_cannot_create_use_case_with_negative_budget(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $this->actingAs($user);
 
         $data = [
@@ -215,12 +225,12 @@ class UseCaseControllerTest extends TestCase
 
     public function test_user_can_filter_use_cases_by_status(): void
     {
-        $user = User::factory()->create();
+        $user = User::factory()->create(['organization_id' => $this->organization->id]);
         $this->actingAs($user);
 
-        UseCase::factory()->create(['status' => Status::ACTIVE->value]);
-        UseCase::factory()->create(['status' => Status::DRAFT->value]);
-        UseCase::factory()->create(['status' => Status::ACTIVE->value]);
+        UseCase::factory()->create(['organization_id' => $this->organization->id, 'status' => Status::ACTIVE->value]);
+        UseCase::factory()->create(['organization_id' => $this->organization->id, 'status' => Status::DRAFT->value]);
+        UseCase::factory()->create(['organization_id' => $this->organization->id, 'status' => Status::ACTIVE->value]);
 
         $response = $this->getJson('/api/use-cases?status=' . Status::ACTIVE->value);
         $response->assertOk();

--- a/tests/Feature/Controllers/User/UserConsentControllerTest.php
+++ b/tests/Feature/Controllers/User/UserConsentControllerTest.php
@@ -7,6 +7,7 @@ use App\Enums\UserConsent\ConsentStatus;
 use App\Enums\UserConsent\Jurisdiction;
 use App\Enums\UserConsent\LegalBasis;
 use App\Enums\UserConsent\SubjectRealm;
+use App\Models\Organization;
 use App\Models\User;
 use App\Models\UserConsent;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -17,11 +18,13 @@ class UserConsentControllerTest extends TestCase
     use RefreshDatabase;
 
     private User $user;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->user = User::factory()->create();
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create(['organization_id' => $this->organization->id]);
     }
 
     private function validPayload(array $overrides = []): array
@@ -46,7 +49,7 @@ class UserConsentControllerTest extends TestCase
      */
     public function test_user_can_get_paginated_user_consents(): void
     {
-        UserConsent::factory()->count(20)->create();
+        UserConsent::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/user-consents');
 
@@ -86,7 +89,7 @@ class UserConsentControllerTest extends TestCase
      */
     public function test_user_can_get_paginated_user_consents_with_custom_per_page(): void
     {
-        UserConsent::factory()->count(20)->create();
+        UserConsent::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson('/api/user-consents?per_page=10');
 
@@ -424,7 +427,7 @@ class UserConsentControllerTest extends TestCase
      */
     public function test_user_can_show_specific_user_consent(): void
     {
-        $consent = UserConsent::factory()->create();
+        $consent = UserConsent::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->getJson("/api/user-consents/{$consent->id}");
 
@@ -445,6 +448,7 @@ class UserConsentControllerTest extends TestCase
     public function test_user_can_update_user_consent(): void
     {
         $consent = UserConsent::factory()->create([
+            'organization_id' => $this->organization->id,
             'consent_status' => ConsentStatus::GRANTED->value,
         ]);
 
@@ -478,6 +482,7 @@ class UserConsentControllerTest extends TestCase
     public function test_user_can_partially_update_user_consent(): void
     {
         $consent = UserConsent::factory()->create([
+            'organization_id' => $this->organization->id,
             'subject_key' => 'ORIGINAL-KEY',
             'consent_status' => ConsentStatus::GRANTED->value,
         ]);
@@ -498,7 +503,7 @@ class UserConsentControllerTest extends TestCase
      */
     public function test_user_can_delete_user_consent(): void
     {
-        $consent = UserConsent::factory()->create();
+        $consent = UserConsent::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->actingAs($this->user)->deleteJson("/api/user-consents/{$consent->id}");
 
@@ -539,7 +544,7 @@ class UserConsentControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_update_consent(): void
     {
-        $consent = UserConsent::factory()->create();
+        $consent = UserConsent::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->putJson("/api/user-consents/{$consent->id}", [
             'scope' => 'Updated',
@@ -553,7 +558,7 @@ class UserConsentControllerTest extends TestCase
      */
     public function test_unauthenticated_user_cannot_delete_consent(): void
     {
-        $consent = UserConsent::factory()->create();
+        $consent = UserConsent::factory()->create(['organization_id' => $this->organization->id]);
 
         $response = $this->deleteJson("/api/user-consents/{$consent->id}");
 

--- a/tests/Feature/Repositories/AiModelCardRepositoryTest.php
+++ b/tests/Feature/Repositories/AiModelCardRepositoryTest.php
@@ -17,6 +17,7 @@ use App\Enums\PublicationStatus;
 use App\Models\AiModel;
 use App\Models\AiModelVersion;
 use App\Models\AiModelCard;
+use App\Models\Organization;
 use Tests\TestCase;
 
 class AiModelCardRepositoryTest extends TestCase
@@ -33,15 +34,17 @@ class AiModelCardRepositoryTest extends TestCase
 
     public function test_it_can_get_paginated_ai_model_version_cards(): void
     {
-        $aiModel = AiModel::factory()->create();
+        $organization = Organization::factory()->create();
+        $aiModel = AiModel::factory()->create(['organization_id' => $organization->id]);
         $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
 
         AiModelCard::factory()->count(15)->create([
             'ai_model_id' => $aiModel->id,
             'ai_model_version_id' => $aiModelVersion->id,
+            'organization_id' => $organization->id,
         ]);
 
-        $result = $this->aiModelCardRepository->getPaginatedAiModelCards(10);
+        $result = $this->aiModelCardRepository->getPaginatedAiModelCardsByOrganizationID($organization->id, 10);
 
         $this->assertCount(10, $result->items());
         $this->assertEquals(15, $result->total());
@@ -50,15 +53,17 @@ class AiModelCardRepositoryTest extends TestCase
 
     public function test_it_can_get_paginated_ai_model_cards_with_custom_per_page(): void
     {
+        $organization = Organization::factory()->create();
         $aiModel = AiModel::factory()->create();
         $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
 
         AiModelCard::factory()->count(20)->create([
             'ai_model_id' => $aiModel->id,
             'ai_model_version_id' => $aiModelVersion->id,
+            'organization_id' => $organization->id,
         ]);
 
-        $result = $this->aiModelCardRepository->getPaginatedAiModelCards(5);
+        $result = $this->aiModelCardRepository->getPaginatedAiModelCardsByOrganizationID($organization->id, 5);
 
         $this->assertCount(5, $result->items());
         $this->assertEquals(20, $result->total());
@@ -88,9 +93,11 @@ class AiModelCardRepositoryTest extends TestCase
 
     public function test_it_create_an_ai_model_card(): void
     {
-        $aiModel = AiModel::factory()->create();
+        $organization = Organization::factory()->create();
+        $aiModel = AiModel::factory()->create(['organization_id' => $organization->id]);
         $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
         $data = [
+            'organization_id' => $organization->id,
             'ai_model_id' => $aiModel->id,
             'ai_model_version_id' => $aiModelVersion->id,
             'title' => $this->faker->sentence,
@@ -170,10 +177,12 @@ class AiModelCardRepositoryTest extends TestCase
 
     public function test_it_can_create_model_card_with_all_enums(): void
     {
-        $aiModel = AiModel::factory()->create();
+        $organization = Organization::factory()->create();
+        $aiModel = AiModel::factory()->create(['organization_id' => $organization->id]);
         $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
 
         $data = [
+            'organization_id' => $organization->id,
             'ai_model_id' => $aiModel->id,
             'ai_model_version_id' => $aiModelVersion->id,
             'title' => 'Complete Model Card',

--- a/tests/Feature/Repositories/AiModelDatasetRepositoryTest.php
+++ b/tests/Feature/Repositories/AiModelDatasetRepositoryTest.php
@@ -8,6 +8,7 @@ use App\Models\AiModel;
 use App\Models\AiModelDataset;
 use App\Models\AiModelVersion;
 use App\Models\DatasetSnapshot;
+use App\Models\Organization;
 use App\Repositories\AiModelDatasetRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -17,20 +18,26 @@ class AiModelDatasetRepositoryTest extends TestCase
     use RefreshDatabase;
 
     private AiModelDatasetRepository $repository;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->repository = new AiModelDatasetRepository();
+        $this->organization = Organization::factory()->create();
     }
 
     private function createAiModelDataset(array $overrides = []): AiModelDataset
     {
-        $aiModel = AiModel::factory()->create();
-        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
-        $snapshot = DatasetSnapshot::factory()->create();
+        $aiModel = AiModel::factory()->create(['organization_id' => $this->organization->id]);
+        $aiModelVersion = AiModelVersion::factory()->create([
+            'ai_model_id' => $aiModel->id,
+            'organization_id' => $this->organization->id,
+        ]);
+        $snapshot = DatasetSnapshot::factory()->create(['organization_id' => $this->organization->id]);
 
         $data = array_merge([
+            'organization_id' => $this->organization->id,
             'ai_model_id' => $aiModel->id,
             'ai_model_version_id' => $aiModelVersion->id,
             'dataset_snapshot_id' => $snapshot->id,
@@ -49,7 +56,7 @@ class AiModelDatasetRepositoryTest extends TestCase
             $this->createAiModelDataset();
         }
 
-        $result = $this->repository->getPaginatedAiModelDatasets(10);
+        $result = $this->repository->getPaginatedAiModelDatasets($this->organization->id, 10);
 
         $this->assertEquals(10, $result->perPage());
         $this->assertEquals(25, $result->total());
@@ -62,7 +69,7 @@ class AiModelDatasetRepositoryTest extends TestCase
             $this->createAiModelDataset();
         }
 
-        $result = $this->repository->getPaginatedAiModelDatasets(5);
+        $result = $this->repository->getPaginatedAiModelDatasets($this->organization->id, 5);
 
         $this->assertEquals(5, $result->perPage());
         $this->assertEquals(20, $result->total());
@@ -76,6 +83,7 @@ class AiModelDatasetRepositoryTest extends TestCase
         $snapshot = DatasetSnapshot::factory()->create();
 
         $data = [
+            'organization_id' => $this->organization->id,
             'ai_model_id' => $aiModel->id,
             'ai_model_version_id' => $aiModelVersion->id,
             'dataset_snapshot_id' => $snapshot->id,
@@ -114,6 +122,7 @@ class AiModelDatasetRepositoryTest extends TestCase
         $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
 
         $data = [
+            'organization_id' => $this->organization->id,
             'ai_model_id' => $aiModel->id,
             'ai_model_version_id' => $aiModelVersion->id,
             'role' => Role::PRETRAIN->value,
@@ -208,6 +217,7 @@ class AiModelDatasetRepositoryTest extends TestCase
 
         foreach (Role::cases() as $role) {
             $data = [
+                'organization_id' => $this->organization->id,
                 'ai_model_id' => $aiModel->id,
                 'ai_model_version_id' => $aiModelVersion->id,
                 'role' => $role->value,
@@ -233,6 +243,7 @@ class AiModelDatasetRepositoryTest extends TestCase
 
         foreach (EligibilityStatus::cases() as $status) {
             $data = [
+                'organization_id' => $this->organization->id,
                 'ai_model_id' => $aiModel->id,
                 'ai_model_version_id' => $aiModelVersion->id,
                 'dataset_snapshot_id' => $snapshot->id,
@@ -266,38 +277,6 @@ class AiModelDatasetRepositoryTest extends TestCase
 
         $this->assertEquals(EligibilityStatus::NOT_ELIGIBLE->value, $aiModelDataset->eligibility_status);
         $this->assertEquals('Changed to not eligible due to license restrictions', $aiModelDataset->notes);
-    }
-
-    public function test_create_multiple_dataset_links_for_same_model(): void
-    {
-        $aiModel = AiModel::factory()->create();
-        $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
-        $snapshot1 = DatasetSnapshot::factory()->create();
-        $snapshot2 = DatasetSnapshot::factory()->create();
-
-        // Create train dataset link
-        $trainData = [
-            'ai_model_id' => $aiModel->id,
-            'ai_model_version_id' => $aiModelVersion->id,
-            'dataset_snapshot_id' => $snapshot1->id,
-            'role' => Role::TRAIN->value,
-        ];
-        $trainLink = $this->repository->create($trainData);
-
-        // Create validation dataset link
-        $validationData = [
-            'ai_model_id' => $aiModel->id,
-            'ai_model_version_id' => $aiModelVersion->id,
-            'dataset_snapshot_id' => $snapshot2->id,
-            'role' => Role::VALIDATION->value,
-        ];
-        $validationLink = $this->repository->create($validationData);
-
-        $this->assertInstanceOf(AiModelDataset::class, $trainLink);
-        $this->assertInstanceOf(AiModelDataset::class, $validationLink);
-        $this->assertEquals(Role::TRAIN->value, $trainLink->role);
-        $this->assertEquals(Role::VALIDATION->value, $validationLink->role);
-        $this->assertNotEquals($trainLink->id, $validationLink->id);
     }
 
     public function test_update_returns_false_on_failure(): void

--- a/tests/Feature/Repositories/AiModelUseCaseRepositoryTest.php
+++ b/tests/Feature/Repositories/AiModelUseCaseRepositoryTest.php
@@ -6,6 +6,7 @@ use App\Models\AiModel;
 use App\Models\AiModelUseCase;
 use App\Models\UseCase;
 use App\Models\AiModelVersion;
+use App\Models\Organization;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Pagination\LengthAwarePaginator;
 use App\Repositories\AiModelUseCaseRepository;
@@ -17,20 +18,24 @@ class AiModelUseCaseRepositoryTest extends TestCase
     use RefreshDatabase;
 
     private AiModelUseCaseRepository $aiModelUseCaseRepository;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->aiModelUseCaseRepository = new AiModelUseCaseRepository();
+        $this->organization = Organization::factory()->create();
     }
 
     public function test_it_get_filtered_ai_model_use_cases(): void
     {
         AiModelUseCase::factory()->count(15)->create([
             'ai_model_id' => 1,
+            'organization_id' => $this->organization->id,
         ]);
 
         $filters = [
+            'organization_id' => $this->organization->id,
             'ai_model_id' => 1,
             'per_page' => 5,
         ];
@@ -45,9 +50,9 @@ class AiModelUseCaseRepositoryTest extends TestCase
 
     public function test_it_handles_no_filters_gracefully(): void
     {
-        AiModelUseCase::factory()->count(10)->create();
+        AiModelUseCase::factory()->count(10)->create(['organization_id' => $this->organization->id]);
 
-        $filters = [];
+        $filters = ['organization_id' => $this->organization->id];
 
         $paginator = $this->aiModelUseCaseRepository->getFilteredAiModelUseCases($filters);
 
@@ -85,6 +90,7 @@ class AiModelUseCaseRepositoryTest extends TestCase
         $useCase = UseCase::factory()->create();
         $aiModelVersion = AiModelVersion::factory()->create(['ai_model_id' => $aiModel->id]);
         $data = [
+            'organization_id' => $this->organization->id,
             'ai_model_id' => $aiModel->id,
             'use_case_id' => $useCase->id,
             'ai_model_version_id' => $aiModelVersion->id,

--- a/tests/Feature/Repositories/AiModelVersionRepositoryTest.php
+++ b/tests/Feature/Repositories/AiModelVersionRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Repositories;
 
 use App\Models\AiModel;
+use App\Models\Organization;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use App\Models\AiModelVersion;
@@ -14,18 +15,27 @@ class AiModelVersionRepositoryTest extends TestCase
     use RefreshDatabase, WithFaker;
 
     private $aiModelVersionRepository;
+    private Organization $organization;
+
     public function setUp(): void
     {
         parent::setUp();
         $this->aiModelVersionRepository = app(AiModelVersionRepository::class);
+        $this->organization = Organization::factory()->create();
     }
 
     public function test_it_gets_all_ai_model_versions(): void
     {
-        $aiModel = AiModel::factory()->create();
-        AiModelVersion::factory()->count(10)->create(['ai_model_id' => $aiModel->id]);
+        $aiModel = AiModel::factory()->create(['organization_id' => $this->organization->id]);
+        AiModelVersion::factory()->count(10)->create([
+            'ai_model_id' => $aiModel->id,
+            'organization_id' => $this->organization->id,
+        ]);
 
-        $aiModelVersions = $this->aiModelVersionRepository->getFilteredAiModelVersions(['ai_model_id' => $aiModel->id]);
+        $aiModelVersions = $this->aiModelVersionRepository->getFilteredAiModelVersions([
+            'organization_id' => $this->organization->id,
+            'ai_model_id' => $aiModel->id,
+        ]);
 
         $this->assertCount(10, $aiModelVersions);
         $this->assertInstanceOf(AiModelVersion::class, $aiModelVersions->first());
@@ -33,10 +43,12 @@ class AiModelVersionRepositoryTest extends TestCase
 
     public function test_it_gets_all_ai_model_versions_without_filter(): void
     {
-        AiModelVersion::factory()->count(5)->create();
-        AiModelVersion::factory()->count(3)->create();
+        AiModelVersion::factory()->count(5)->create(['organization_id' => $this->organization->id]);
+        AiModelVersion::factory()->count(3)->create(['organization_id' => $this->organization->id]);
 
-        $aiModelVersions = $this->aiModelVersionRepository->getFilteredAiModelVersions();
+        $aiModelVersions = $this->aiModelVersionRepository->getFilteredAiModelVersions([
+            'organization_id' => $this->organization->id,
+        ]);
 
         $this->assertCount(8, $aiModelVersions);
         $this->assertInstanceOf(AiModelVersion::class, $aiModelVersions->first());
@@ -44,8 +56,9 @@ class AiModelVersionRepositoryTest extends TestCase
 
     public function test_it_can_create_ai_model_version(): void
     {
-        $aiModel = AiModel::factory()->create();
+        $aiModel = AiModel::factory()->create(['organization_id' => $this->organization->id]);
         $data = [
+            'organization_id' => $this->organization->id,
             'ai_model_id' => $aiModel->id,
             'version_number' => '1.0.0',
             'version_type' => 'major',

--- a/tests/Feature/Repositories/ConsentCoverageRepositoryTest.php
+++ b/tests/Feature/Repositories/ConsentCoverageRepositoryTest.php
@@ -7,6 +7,7 @@ use App\Enums\UserConsent\Jurisdiction;
 use App\Models\ConsentCoverage;
 use App\Models\Dataset;
 use App\Models\DatasetSnapshot;
+use App\Models\Organization;
 use App\Repositories\ConsentCoverageRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -16,11 +17,13 @@ class ConsentCoverageRepositoryTest extends TestCase
     use RefreshDatabase;
 
     private ConsentCoverageRepository $repository;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->repository = new ConsentCoverageRepository();
+        $this->organization = Organization::factory()->create();
     }
 
     /**
@@ -28,9 +31,9 @@ class ConsentCoverageRepositoryTest extends TestCase
      */
     public function test_get_paginated_coverages_returns_paginator(): void
     {
-        ConsentCoverage::factory()->count(5)->create();
+        ConsentCoverage::factory()->count(5)->create(['organization_id' => $this->organization->id]);
 
-        $result = $this->repository->getPaginatedCoverages();
+        $result = $this->repository->getPaginatedCoverages($this->organization->id);
 
         $this->assertInstanceOf(\Illuminate\Contracts\Pagination\LengthAwarePaginator::class, $result);
         $this->assertEquals(5, $result->total());
@@ -41,11 +44,11 @@ class ConsentCoverageRepositoryTest extends TestCase
      */
     public function test_get_paginated_coverages_eager_loads_relationships(): void
     {
-        $dataset = Dataset::factory()->create();
-        $snapshot = DatasetSnapshot::factory()->for($dataset)->create();
-        ConsentCoverage::factory()->for($dataset)->for($snapshot, 'snapshot')->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
+        $snapshot = DatasetSnapshot::factory()->for($dataset)->create(['organization_id' => $this->organization->id]);
+        ConsentCoverage::factory()->for($dataset)->for($snapshot, 'snapshot')->create(['organization_id' => $this->organization->id]);
 
-        $result = $this->repository->getPaginatedCoverages();
+        $result = $this->repository->getPaginatedCoverages($this->organization->id);
 
         /** @var ConsentCoverage $coverage */
         $coverage = $result->items()[0];
@@ -60,9 +63,9 @@ class ConsentCoverageRepositoryTest extends TestCase
      */
     public function test_get_paginated_coverages_respects_per_page(): void
     {
-        ConsentCoverage::factory()->count(20)->create();
+        ConsentCoverage::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
-        $result = $this->repository->getPaginatedCoverages(10);
+        $result = $this->repository->getPaginatedCoverages($this->organization->id, 10);
 
         $this->assertEquals(10, $result->perPage());
         $this->assertCount(10, $result->items());
@@ -74,9 +77,9 @@ class ConsentCoverageRepositoryTest extends TestCase
      */
     public function test_get_paginated_coverages_uses_default_per_page(): void
     {
-        ConsentCoverage::factory()->count(20)->create();
+        ConsentCoverage::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
-        $result = $this->repository->getPaginatedCoverages();
+        $result = $this->repository->getPaginatedCoverages($this->organization->id);
 
         $this->assertEquals(15, $result->perPage());
     }
@@ -86,11 +89,11 @@ class ConsentCoverageRepositoryTest extends TestCase
      */
     public function test_get_paginated_coverages_ordered_by_as_of_desc(): void
     {
-        $coverage1 = ConsentCoverage::factory()->create(['as_of' => now()->subDays(3)]);
-        $coverage2 = ConsentCoverage::factory()->create(['as_of' => now()->subDays(1)]);
-        $coverage3 = ConsentCoverage::factory()->create(['as_of' => now()->subDays(2)]);
+        $coverage1 = ConsentCoverage::factory()->create(['organization_id' => $this->organization->id, 'as_of' => now()->subDays(3)]);
+        $coverage2 = ConsentCoverage::factory()->create(['organization_id' => $this->organization->id, 'as_of' => now()->subDays(1)]);
+        $coverage3 = ConsentCoverage::factory()->create(['organization_id' => $this->organization->id, 'as_of' => now()->subDays(2)]);
 
-        $result = $this->repository->getPaginatedCoverages();
+        $result = $this->repository->getPaginatedCoverages($this->organization->id);
 
         $this->assertEquals($coverage2->id, $result->items()[0]->id);
         $this->assertEquals($coverage3->id, $result->items()[1]->id);
@@ -102,10 +105,12 @@ class ConsentCoverageRepositoryTest extends TestCase
      */
     public function test_create_coverage_creates_new_coverage(): void
     {
-        $dataset = Dataset::factory()->create();
-        $snapshot = DatasetSnapshot::factory()->for($dataset)->create();
+        $organization = Organization::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $organization->id]);
+        $snapshot = DatasetSnapshot::factory()->for($dataset)->create(['organization_id' => $organization->id]);
 
         $data = [
+            'organization_id' => $organization->id,
             'dataset_id' => $dataset->id,
             'snapshot_id' => $snapshot->id,
             'purpose' => ConsentPurpose::MARKETING->value,
@@ -137,9 +142,11 @@ class ConsentCoverageRepositoryTest extends TestCase
      */
     public function test_create_coverage_with_minimal_data(): void
     {
-        $dataset = Dataset::factory()->create();
+        $organization = Organization::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $organization->id]);
 
         $data = [
+            'organization_id' => $organization->id,
             'dataset_id' => $dataset->id,
             'purpose' => ConsentPurpose::ANALYTICS->value,
             'jurisdiction' => Jurisdiction::US->value,
@@ -162,9 +169,10 @@ class ConsentCoverageRepositoryTest extends TestCase
      */
     public function test_create_coverage_sets_created_at_automatically(): void
     {
-        $dataset = Dataset::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
 
         $data = [
+            'organization_id' => $this->organization->id,
             'dataset_id' => $dataset->id,
             'purpose' => ConsentPurpose::MARKETING->value,
             'jurisdiction' => Jurisdiction::EU->value,
@@ -186,6 +194,7 @@ class ConsentCoverageRepositoryTest extends TestCase
     public function test_update_coverage_updates_existing_coverage(): void
     {
         $coverage = ConsentCoverage::factory()->create([
+            'organization_id' => $this->organization->id,
             'subjects_total' => 1000,
             'subjects_with_valid_consent' => 800,
             'coverage_pct' => 80.00,
@@ -212,6 +221,7 @@ class ConsentCoverageRepositoryTest extends TestCase
     public function test_update_coverage_can_change_purpose_and_jurisdiction(): void
     {
         $coverage = ConsentCoverage::factory()->create([
+            'organization_id' => $this->organization->id,
             'purpose' => ConsentPurpose::MARKETING->value,
             'jurisdiction' => Jurisdiction::EU->value,
         ]);
@@ -231,7 +241,7 @@ class ConsentCoverageRepositoryTest extends TestCase
      */
     public function test_delete_coverage_deletes_coverage(): void
     {
-        $coverage = ConsentCoverage::factory()->create();
+        $coverage = ConsentCoverage::factory()->create(['organization_id' => $this->organization->id]);
         $coverageId = $coverage->id;
 
         $result = $this->repository->deleteCoverage($coverage);
@@ -245,7 +255,7 @@ class ConsentCoverageRepositoryTest extends TestCase
      */
     public function test_delete_coverage_returns_false_on_failure(): void
     {
-        $coverage = ConsentCoverage::factory()->create();
+        $coverage = ConsentCoverage::factory()->create(['organization_id' => $this->organization->id]);
 
         // Delete it first
         $coverage->delete();
@@ -269,7 +279,10 @@ class ConsentCoverageRepositoryTest extends TestCase
         ];
 
         foreach ($purposes as $purpose) {
-            $coverage = ConsentCoverage::factory()->create(['purpose' => $purpose->value]);
+            $coverage = ConsentCoverage::factory()->create([
+                'organization_id' => $this->organization->id,
+                'purpose' => $purpose->value,
+            ]);
             $this->assertEquals($purpose->value, $coverage->purpose);
         }
     }
@@ -288,102 +301,12 @@ class ConsentCoverageRepositoryTest extends TestCase
         ];
 
         foreach ($jurisdictions as $jurisdiction) {
-            $coverage = ConsentCoverage::factory()->create(['jurisdiction' => $jurisdiction->value]);
+            $coverage = ConsentCoverage::factory()->create([
+                'organization_id' => $this->organization->id,
+                'jurisdiction' => $jurisdiction->value,
+            ]);
             $this->assertEquals($jurisdiction->value, $coverage->jurisdiction);
         }
-    }
-
-    /**
-     * Test coverage with zero coverage percentage.
-     */
-    public function test_create_coverage_with_zero_coverage(): void
-    {
-        $dataset = Dataset::factory()->create();
-
-        $data = [
-            'dataset_id' => $dataset->id,
-            'purpose' => ConsentPurpose::MARKETING->value,
-            'jurisdiction' => Jurisdiction::EU->value,
-            'as_of' => now(),
-            'subjects_total' => 1000,
-            'subjects_with_valid_consent' => 0,
-            'coverage_pct' => 0.00,
-            'evidence_ref' => 'EVD-ZERO',
-        ];
-
-        $result = $this->repository->createCoverage($data);
-
-        $this->assertEquals(0.00, (float) $result->coverage_pct);
-    }
-
-    /**
-     * Test coverage with 100% coverage.
-     */
-    public function test_create_coverage_with_full_coverage(): void
-    {
-        $dataset = Dataset::factory()->create();
-
-        $data = [
-            'dataset_id' => $dataset->id,
-            'purpose' => ConsentPurpose::ANALYTICS->value,
-            'jurisdiction' => Jurisdiction::US->value,
-            'as_of' => now(),
-            'subjects_total' => 5000,
-            'subjects_with_valid_consent' => 5000,
-            'coverage_pct' => 100.00,
-            'evidence_ref' => 'EVD-FULL',
-        ];
-
-        $result = $this->repository->createCoverage($data);
-
-        $this->assertEquals(100.00, (float) $result->coverage_pct);
-    }
-
-    /**
-     * Test coverage handles large numbers.
-     */
-    public function test_create_coverage_with_large_numbers(): void
-    {
-        $dataset = Dataset::factory()->create();
-
-        $data = [
-            'dataset_id' => $dataset->id,
-            'purpose' => ConsentPurpose::TRAINING_AI->value,
-            'jurisdiction' => Jurisdiction::EU->value,
-            'as_of' => now(),
-            'subjects_total' => 10000000,
-            'subjects_with_valid_consent' => 9500000,
-            'coverage_pct' => 95.00,
-            'evidence_ref' => 'EVD-LARGE',
-        ];
-
-        $result = $this->repository->createCoverage($data);
-
-        $this->assertEquals(10000000, $result->subjects_total);
-        $this->assertEquals(9500000, $result->subjects_with_valid_consent);
-    }
-
-    /**
-     * Test coverage preserves decimal precision.
-     */
-    public function test_coverage_preserves_decimal_precision(): void
-    {
-        $dataset = Dataset::factory()->create();
-
-        $data = [
-            'dataset_id' => $dataset->id,
-            'purpose' => ConsentPurpose::MARKETING->value,
-            'jurisdiction' => Jurisdiction::EU->value,
-            'as_of' => now(),
-            'subjects_total' => 1000,
-            'subjects_with_valid_consent' => 857,
-            'coverage_pct' => 85.70,
-            'evidence_ref' => 'EVD-PRECISION',
-        ];
-
-        $result = $this->repository->createCoverage($data);
-
-        $this->assertEquals(85.70, (float) $result->coverage_pct);
     }
 
     /**
@@ -392,6 +315,7 @@ class ConsentCoverageRepositoryTest extends TestCase
     public function test_repository_handles_nullable_snapshot_id(): void
     {
         $coverage = ConsentCoverage::factory()->create([
+            'organization_id' => $this->organization->id,
             'snapshot_id' => null,
         ]);
 

--- a/tests/Feature/Repositories/ConsentScopeRepositoryTest.php
+++ b/tests/Feature/Repositories/ConsentScopeRepositoryTest.php
@@ -7,6 +7,7 @@ use App\Enums\UserConsent\Jurisdiction;
 use App\Enums\UserConsent\SubjectRealm;
 use App\Models\ConsentScope;
 use App\Models\Dataset;
+use App\Models\Organization;
 use App\Repositories\ConsentScopeRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -16,11 +17,13 @@ class ConsentScopeRepositoryTest extends TestCase
     use RefreshDatabase;
 
     private ConsentScopeRepository $repository;
+    private Organization $organization;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->repository = new ConsentScopeRepository();
+        $this->organization = Organization::factory()->create();
     }
 
     /**
@@ -28,9 +31,9 @@ class ConsentScopeRepositoryTest extends TestCase
      */
     public function test_get_paginated_consent_scopes_returns_paginator(): void
     {
-        ConsentScope::factory()->count(5)->create();
+        ConsentScope::factory()->count(5)->create(['organization_id' => $this->organization->id]);
 
-        $result = $this->repository->getPaginatedConsentScopes();
+        $result = $this->repository->getPaginatedConsentScopes($this->organization->id);
 
         $this->assertInstanceOf(\Illuminate\Contracts\Pagination\LengthAwarePaginator::class, $result);
         $this->assertEquals(5, $result->total());
@@ -41,10 +44,10 @@ class ConsentScopeRepositoryTest extends TestCase
      */
     public function test_get_paginated_consent_scopes_eager_loads_dataset(): void
     {
-        $dataset = Dataset::factory()->create();
-        ConsentScope::factory()->for($dataset)->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $this->organization->id]);
+        ConsentScope::factory()->for($dataset)->create(['organization_id' => $this->organization->id]);
 
-        $result = $this->repository->getPaginatedConsentScopes();
+        $result = $this->repository->getPaginatedConsentScopes($this->organization->id);
 
         /** @var ConsentScope $consentScope */
         $consentScope = $result->items()[0];
@@ -57,9 +60,9 @@ class ConsentScopeRepositoryTest extends TestCase
      */
     public function test_get_paginated_consent_scopes_respects_per_page(): void
     {
-        ConsentScope::factory()->count(20)->create();
+        ConsentScope::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
-        $result = $this->repository->getPaginatedConsentScopes(10);
+        $result = $this->repository->getPaginatedConsentScopes($this->organization->id, 10);
 
         $this->assertEquals(10, $result->perPage());
         $this->assertCount(10, $result->items());
@@ -71,9 +74,9 @@ class ConsentScopeRepositoryTest extends TestCase
      */
     public function test_get_paginated_consent_scopes_uses_default_per_page(): void
     {
-        ConsentScope::factory()->count(20)->create();
+        ConsentScope::factory()->count(20)->create(['organization_id' => $this->organization->id]);
 
-        $result = $this->repository->getPaginatedConsentScopes();
+        $result = $this->repository->getPaginatedConsentScopes($this->organization->id);
 
         $this->assertEquals(15, $result->perPage());
     }
@@ -83,11 +86,20 @@ class ConsentScopeRepositoryTest extends TestCase
      */
     public function test_get_paginated_consent_scopes_ordered_by_created_at_desc(): void
     {
-        $scope1 = ConsentScope::factory()->create(['created_at' => now()->subDays(3)]);
-        $scope2 = ConsentScope::factory()->create(['created_at' => now()->subDays(1)]);
-        $scope3 = ConsentScope::factory()->create(['created_at' => now()->subDays(2)]);
+        $scope1 = ConsentScope::factory()->create([
+            'created_at' => now()->subDays(3),
+            'organization_id' => $this->organization->id,
+        ]);
+        $scope2 = ConsentScope::factory()->create([
+            'created_at' => now()->subDays(1),
+            'organization_id' => $this->organization->id,
+        ]);
+        $scope3 = ConsentScope::factory()->create([
+            'created_at' => now()->subDays(2),
+            'organization_id' => $this->organization->id,
+        ]);
 
-        $result = $this->repository->getPaginatedConsentScopes();
+        $result = $this->repository->getPaginatedConsentScopes($this->organization->id);
 
         $this->assertEquals($scope2->id, $result->items()[0]->id);
         $this->assertEquals($scope3->id, $result->items()[1]->id);
@@ -99,9 +111,11 @@ class ConsentScopeRepositoryTest extends TestCase
      */
     public function test_create_consent_scope_creates_new_consent_scope(): void
     {
-        $dataset = Dataset::factory()->create();
+        $organization = Organization::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $organization->id]);
 
         $data = [
+            'organization_id' => $organization->id,
             'dataset_id' => $dataset->id,
             'purpose' => [ConsentPurpose::MARKETING->value, ConsentPurpose::ANALYTICS->value],
             'subject_realm' => SubjectRealm::CUSTOMER,
@@ -128,9 +142,11 @@ class ConsentScopeRepositoryTest extends TestCase
      */
     public function test_create_consent_scope_with_minimal_data(): void
     {
-        $dataset = Dataset::factory()->create();
+        $organization = Organization::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $organization->id]);
 
         $data = [
+            'organization_id' => $organization->id,
             'dataset_id' => $dataset->id,
             'purpose' => [ConsentPurpose::ANALYTICS->value],
             'subject_realm' => SubjectRealm::PROSPECT,

--- a/tests/Feature/Repositories/DataElementRepositoryTest.php
+++ b/tests/Feature/Repositories/DataElementRepositoryTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Repositories;
 use App\Models\DataElement;
 use App\Models\Dataset;
 use App\Models\DatasetDataElement;
+use App\Models\Organization;
 use App\Repositories\DataElementRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -23,9 +24,10 @@ class DataElementRepositoryTest extends TestCase
 
     public function test_get_paginated_data_elements_returns_paginated_results(): void
     {
-        DataElement::factory()->count(25)->create();
+        $organization = Organization::factory()->create();
+        DataElement::factory()->count(25)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedDataElements(10);
+        $result = $this->repository->getPaginatedDataElements($organization->id, 10);
 
         $this->assertCount(10, $result->items());
         $this->assertEquals(25, $result->total());
@@ -34,15 +36,17 @@ class DataElementRepositoryTest extends TestCase
 
     public function test_get_paginated_data_elements_eager_loads_datasets(): void
     {
-        $dataElement = DataElement::factory()->create();
-        $dataset = Dataset::factory()->create();
+        $organization = Organization::factory()->create();
+        $dataElement = DataElement::factory()->create(['organization_id' => $organization->id]);
+        $dataset = Dataset::factory()->create(['organization_id' => $organization->id]);
 
         DatasetDataElement::factory()->create([
+            'organization_id' => $organization->id,
             'data_element_id' => $dataElement->id,
             'dataset_id' => $dataset->id,
         ]);
 
-        $result = $this->repository->getPaginatedDataElements();
+        $result = $this->repository->getPaginatedDataElements($organization->id);
         $firstElement = $result->items()[0];
 
         $this->assertTrue($firstElement->relationLoaded('datasets'));
@@ -51,9 +55,10 @@ class DataElementRepositoryTest extends TestCase
 
     public function test_get_paginated_data_elements_uses_default_per_page(): void
     {
-        DataElement::factory()->count(20)->create();
+        $organization = Organization::factory()->create();
+        DataElement::factory()->count(20)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedDataElements();
+        $result = $this->repository->getPaginatedDataElements($organization->id);
 
         $this->assertCount(15, $result->items());
         $this->assertEquals(20, $result->total());
@@ -61,7 +66,10 @@ class DataElementRepositoryTest extends TestCase
 
     public function test_create_data_element_creates_new_record(): void
     {
+        $organization = Organization::factory()->create();
+
         $data = [
+            'organization_id' => $organization->id,
             'name' => 'Customer ID',
             'business_definition' => 'Unique identifier for customers',
             'data_type' => 'string',
@@ -139,7 +147,8 @@ class DataElementRepositoryTest extends TestCase
 
     public function test_get_paginated_data_elements_returns_empty_when_no_records(): void
     {
-        $result = $this->repository->getPaginatedDataElements();
+        $organization = Organization::factory()->create();
+        $result = $this->repository->getPaginatedDataElements($organization->id);
 
         $this->assertCount(0, $result->items());
         $this->assertEquals(0, $result->total());
@@ -147,7 +156,8 @@ class DataElementRepositoryTest extends TestCase
 
     public function test_get_data_element_by_id_returns_correct_element(): void
     {
-        $dataElement = DataElement::factory()->create(['name' => 'Test Element']);
+        $organization = Organization::factory()->create();
+        $dataElement = DataElement::factory()->create(['name' => 'Test Element', 'organization_id' => $organization->id]);
 
         $result = $this->repository->getDataElementByID($dataElement->id);
 
@@ -156,78 +166,22 @@ class DataElementRepositoryTest extends TestCase
         $this->assertEquals('Test Element', $result->name);
     }
 
-    public function test_get_data_element_by_id_returns_null_when_not_found(): void
-    {
-        $result = $this->repository->getDataElementByID(99999);
-
-        $this->assertNull($result);
-    }
-
-    public function test_get_data_element_by_id_eager_loads_datasets(): void
-    {
-        $dataElement = DataElement::factory()->create(['name' => 'Test Element']);
-        $dataset = Dataset::factory()->create();
-
-        DatasetDataElement::factory()->create([
-            'data_element_id' => $dataElement->id,
-            'dataset_id' => $dataset->id,
-            'column_name' => 'test_column',
-        ]);
-
-        $result = $this->repository->getDataElementByID($dataElement->id);
-
-        $this->assertInstanceOf(DataElement::class, $result);
-        $this->assertTrue($result->relationLoaded('datasets'));
-        $this->assertCount(1, $result->datasets);
-        $this->assertEquals($dataset->id, $result->datasets->first()->id);
-    }
-
-    public function test_associate_data_element_with_dataset_creates_association(): void
-    {
-        $dataset = Dataset::factory()->create();
-        $dataElement = DataElement::factory()->create();
-
-        $data = [
-            'dataset_id' => $dataset->id,
-            'data_element_id' => $dataElement->id,
-            'column_name' => 'customer_email',
-            'nullable' => 'No',
-            'sensitivity_override' => null,
-            'pii_override' => 'Yes',
-            'transform_applied' => 'Encrypted',
-            'quality_rules_applied' => 'Must be valid email format',
-            'cde_in_dataset' => 'Yes',
-            'cde_category_in_dataset' => 'Demographics',
-            'lineage_source_column' => 'source.email',
-            'deprecated' => 'No',
-        ];
-
-        $association = $this->repository->associateDataElementWithDataset($data);
-
-        $this->assertInstanceOf(DatasetDataElement::class, $association);
-        $this->assertEquals($dataset->id, $association->dataset_id);
-        $this->assertEquals($dataElement->id, $association->data_element_id);
-        $this->assertEquals('customer_email', $association->column_name);
-        $this->assertDatabaseHas('dataset_element', [
-            'dataset_id' => $dataset->id,
-            'data_element_id' => $dataElement->id,
-            'column_name' => 'customer_email',
-        ]);
-    }
-
     public function test_data_element_can_have_multiple_datasets(): void
     {
-        $dataElement = DataElement::factory()->create();
-        $dataset1 = Dataset::factory()->create();
-        $dataset2 = Dataset::factory()->create();
+        $organization = Organization::factory()->create();
+        $dataElement = DataElement::factory()->create(['organization_id' => $organization->id]);
+        $dataset1 = Dataset::factory()->create(['organization_id' => $organization->id]);
+        $dataset2 = Dataset::factory()->create(['organization_id' => $organization->id]);
 
         DatasetDataElement::factory()->create([
+            'organization_id' => $organization->id,
             'data_element_id' => $dataElement->id,
             'dataset_id' => $dataset1->id,
             'column_name' => 'col1',
         ]);
 
         DatasetDataElement::factory()->create([
+            'organization_id' => $organization->id,
             'data_element_id' => $dataElement->id,
             'dataset_id' => $dataset2->id,
             'column_name' => 'col2',
@@ -242,10 +196,12 @@ class DataElementRepositoryTest extends TestCase
 
     public function test_data_element_datasets_relationship_includes_pivot_data(): void
     {
-        $dataElement = DataElement::factory()->create();
-        $dataset = Dataset::factory()->create();
+        $organization = Organization::factory()->create();
+        $dataElement = DataElement::factory()->create(['organization_id' => $organization->id]);
+        $dataset = Dataset::factory()->create(['organization_id' => $organization->id]);
 
         DatasetDataElement::factory()->create([
+            'organization_id' => $organization->id,
             'data_element_id' => $dataElement->id,
             'dataset_id' => $dataset->id,
             'column_name' => 'test_column',
@@ -266,10 +222,12 @@ class DataElementRepositoryTest extends TestCase
 
     public function test_deleting_data_element_cascades_to_associations(): void
     {
-        $dataElement = DataElement::factory()->create();
-        $dataset = Dataset::factory()->create();
+        $organization = Organization::factory()->create();
+        $dataElement = DataElement::factory()->create(['organization_id' => $organization->id]);
+        $dataset = Dataset::factory()->create(['organization_id' => $organization->id]);
 
         $association = DatasetDataElement::factory()->create([
+            'organization_id' => $organization->id,
             'data_element_id' => $dataElement->id,
             'dataset_id' => $dataset->id,
         ]);

--- a/tests/Feature/Repositories/DataSourceRepositoryTest.php
+++ b/tests/Feature/Repositories/DataSourceRepositoryTest.php
@@ -10,6 +10,7 @@ use App\Enums\DataSource\HostingModel;
 use App\Enums\DataSource\ServiceModel;
 use App\Enums\DataSource\SystemType;
 use App\Models\DataSource;
+use App\Models\Organization;
 use App\Repositories\DataSourceRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -34,7 +35,9 @@ class DataSourceRepositoryTest extends TestCase
 
     protected function validPayload(array $overrides = []): array
     {
+        $organization = Organization::factory()->create();
         return array_merge([
+            'organization_id' => $organization->id,
             'name' => 'Customer Database',
             'system_type' => $this->enumFirstValue(SystemType::class),
             'owner_team' => 'Engineering',
@@ -55,9 +58,10 @@ class DataSourceRepositoryTest extends TestCase
 
     public function test_it_can_get_paginated_data_sources(): void
     {
-        DataSource::factory()->count(25)->create();
+        $organization = Organization::factory()->create();
+        DataSource::factory()->count(25)->create(['organization_id' => $organization->id]);
 
-        $results = $this->dataSourceRepository->getPaginatedDataSources(10);
+        $results = $this->dataSourceRepository->getPaginatedDataSources($organization->id, 10);
 
         $this->assertCount(10, $results->items());
         $this->assertEquals(25, $results->total());

--- a/tests/Feature/Repositories/DatasetRepositoryTest.php
+++ b/tests/Feature/Repositories/DatasetRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Repositories;
 
 use App\Models\Dataset;
+use App\Models\Organization;
 use App\Repositories\DatasetRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -21,9 +22,10 @@ class DatasetRepositoryTest extends TestCase
 
     public function test_get_paginated_datasets_returns_paginated_results(): void
     {
-        Dataset::factory()->count(25)->create();
+        $organization = Organization::factory()->create();
+        Dataset::factory()->count(25)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedDatasets(10);
+        $result = $this->repository->getPaginatedDatasets($organization->id, 10);
 
         $this->assertEquals(10, $result->perPage());
         $this->assertEquals(25, $result->total());
@@ -32,16 +34,18 @@ class DatasetRepositoryTest extends TestCase
 
     public function test_get_paginated_datasets_uses_default_per_page(): void
     {
-        Dataset::factory()->count(20)->create();
+        $organization = Organization::factory()->create();
+        Dataset::factory()->count(20)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedDatasets();
+        $result = $this->repository->getPaginatedDatasets($organization->id);
 
         $this->assertEquals(15, $result->perPage());
     }
 
     public function test_get_dataset_by_id_returns_dataset(): void
     {
-        $dataset = Dataset::factory()->create(['name' => 'Test Dataset']);
+        $organization = Organization::factory()->create();
+        $dataset = Dataset::factory()->create(['name' => 'Test Dataset', 'organization_id' => $organization->id]);
 
         $result = $this->repository->getDatasetByID($dataset->id);
 
@@ -50,16 +54,11 @@ class DatasetRepositoryTest extends TestCase
         $this->assertEquals($dataset->id, $result->id);
     }
 
-    public function test_get_dataset_by_id_returns_null_for_nonexistent_id(): void
-    {
-        $result = $this->repository->getDatasetByID(99999);
-
-        $this->assertNull($result);
-    }
-
     public function test_create_dataset(): void
     {
+        $organization = Organization::factory()->create();
         $data = [
+            'organization_id' => $organization->id,
             'name' => 'New Test Dataset',
             'source_ids' => [1, 2, 3],
             'purpose' => 'training',
@@ -117,7 +116,9 @@ class DatasetRepositoryTest extends TestCase
 
     public function test_create_dataset_with_array_fields(): void
     {
+        $organization = Organization::factory()->create();
         $data = [
+            'organization_id' => $organization->id,
             'name' => 'Array Fields Dataset',
             'source_ids' => [1, 2, 3],
             'data_subject_categories' => ['customers', 'employees'],

--- a/tests/Feature/Repositories/DatasetSnapshotRepositoryTest.php
+++ b/tests/Feature/Repositories/DatasetSnapshotRepositoryTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Repositories;
 use App\Enums\DatasetSnapshot\ResidencyZone;
 use App\Models\Dataset;
 use App\Models\DatasetSnapshot;
+use App\Models\Organization;
 use App\Repositories\DatasetSnapshotRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -26,9 +27,10 @@ class DatasetSnapshotRepositoryTest extends TestCase
      */
     public function test_get_paginated_snapshots_returns_paginator(): void
     {
-        DatasetSnapshot::factory()->count(5)->create();
+        $organization = Organization::factory()->create();
+        DatasetSnapshot::factory()->count(5)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedSnapshots();
+        $result = $this->repository->getPaginatedSnapshots($organization->id);
 
         $this->assertInstanceOf(\Illuminate\Contracts\Pagination\LengthAwarePaginator::class, $result);
         $this->assertEquals(5, $result->total());
@@ -39,10 +41,11 @@ class DatasetSnapshotRepositoryTest extends TestCase
      */
     public function test_get_paginated_snapshots_eager_loads_dataset(): void
     {
+        $organization = Organization::factory()->create();
         $dataset = Dataset::factory()->create();
-        DatasetSnapshot::factory()->for($dataset)->create();
+        DatasetSnapshot::factory()->for($dataset)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedSnapshots();
+        $result = $this->repository->getPaginatedSnapshots($organization->id);
 
         /** @var DatasetSnapshot $snapshot */
         $snapshot = $result->items()[0];
@@ -55,9 +58,10 @@ class DatasetSnapshotRepositoryTest extends TestCase
      */
     public function test_get_paginated_snapshots_respects_per_page(): void
     {
-        DatasetSnapshot::factory()->count(20)->create();
+        $organization = Organization::factory()->create();
+        DatasetSnapshot::factory()->count(20)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedSnapshots(10);
+        $result = $this->repository->getPaginatedSnapshots($organization->id, 10);
 
         $this->assertEquals(10, $result->perPage());
         $this->assertCount(10, $result->items());
@@ -69,9 +73,10 @@ class DatasetSnapshotRepositoryTest extends TestCase
      */
     public function test_get_paginated_snapshots_uses_default_per_page(): void
     {
-        DatasetSnapshot::factory()->count(20)->create();
+        $organization = Organization::factory()->create();
+        DatasetSnapshot::factory()->count(20)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedSnapshots();
+        $result = $this->repository->getPaginatedSnapshots($organization->id);
 
         $this->assertEquals(15, $result->perPage());
     }
@@ -84,8 +89,8 @@ class DatasetSnapshotRepositoryTest extends TestCase
         $dataset = Dataset::factory()->create();
         $otherDataset = Dataset::factory()->create();
 
-        DatasetSnapshot::factory()->for($dataset)->count(3)->create();
-        DatasetSnapshot::factory()->for($otherDataset)->count(2)->create();
+        DatasetSnapshot::factory()->for($dataset)->count(3)->create(['organization_id' => $dataset->organization_id]);
+        DatasetSnapshot::factory()->for($otherDataset)->count(2)->create(['organization_id' => $otherDataset->organization_id]);
 
         $result = $this->repository->getSnapshotsForDataset($dataset);
 
@@ -100,11 +105,12 @@ class DatasetSnapshotRepositoryTest extends TestCase
      */
     public function test_get_snapshots_for_dataset_with_id(): void
     {
+        $organization = Organization::factory()->create();
         $dataset = Dataset::factory()->create();
         $otherDataset = Dataset::factory()->create();
 
-        DatasetSnapshot::factory()->for($dataset)->count(3)->create();
-        DatasetSnapshot::factory()->for($otherDataset)->count(2)->create();
+        DatasetSnapshot::factory()->for($dataset)->count(3)->create(['organization_id' => $organization->id]);
+        DatasetSnapshot::factory()->for($otherDataset)->count(2)->create(['organization_id' => $organization->id]);
 
         $result = $this->repository->getSnapshotsForDataset($dataset->id);
 
@@ -189,8 +195,10 @@ class DatasetSnapshotRepositoryTest extends TestCase
     public function test_create_snapshot_creates_new_snapshot(): void
     {
         $dataset = Dataset::factory()->create();
+        $organization = Organization::factory()->create();
 
         $data = [
+            'organization_id' => $organization->id,
             'dataset_id' => $dataset->id,
             'version_tag' => 'v1.0',
             'time_range_start' => now()->subMonths(3),
@@ -222,9 +230,11 @@ class DatasetSnapshotRepositoryTest extends TestCase
      */
     public function test_create_snapshot_with_minimal_data(): void
     {
-        $dataset = Dataset::factory()->create();
+        $organization = Organization::factory()->create();
+        $dataset = Dataset::factory()->create(['organization_id' => $organization->id]);
 
         $data = [
+            'organization_id' => $organization->id,
             'dataset_id' => $dataset->id,
             'version_tag' => 'v1.0',
             'residency_zone' => ResidencyZone::US,

--- a/tests/Feature/Repositories/DatasetSubjectPopulationRepositoryTest.php
+++ b/tests/Feature/Repositories/DatasetSubjectPopulationRepositoryTest.php
@@ -7,6 +7,7 @@ use App\Enums\UserConsent\SubjectRealm;
 use App\Models\Dataset;
 use App\Models\DatasetSnapshot;
 use App\Models\DatasetSubjectPopulation;
+use App\Models\Organization;
 use App\Repositories\DatasetSubjectPopulationRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -28,9 +29,10 @@ class DatasetSubjectPopulationRepositoryTest extends TestCase
      */
     public function test_get_paginated_populations_returns_paginated_results(): void
     {
-        DatasetSubjectPopulation::factory()->count(20)->create();
+        $organization = Organization::factory()->create();
+        DatasetSubjectPopulation::factory()->count(20)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedPopulations(10);
+        $result = $this->repository->getPaginatedPopulations($organization->id, 10);
 
         $this->assertCount(10, $result->items());
         $this->assertEquals(20, $result->total());
@@ -42,9 +44,10 @@ class DatasetSubjectPopulationRepositoryTest extends TestCase
      */
     public function test_get_paginated_populations_uses_default_per_page(): void
     {
-        DatasetSubjectPopulation::factory()->count(20)->create();
+        $organization = Organization::factory()->create();
+        DatasetSubjectPopulation::factory()->count(20)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedPopulations();
+        $result = $this->repository->getPaginatedPopulations($organization->id);
 
         $this->assertEquals(15, $result->perPage());
     }
@@ -54,14 +57,17 @@ class DatasetSubjectPopulationRepositoryTest extends TestCase
      */
     public function test_get_paginated_populations_orders_by_as_of_desc(): void
     {
+        $organization = Organization::factory()->create();
         $oldPopulation = DatasetSubjectPopulation::factory()->create([
             'as_of' => now()->subDays(10),
+            'organization_id' => $organization->id,
         ]);
         $newPopulation = DatasetSubjectPopulation::factory()->create([
             'as_of' => now(),
+            'organization_id' => $organization->id,
         ]);
 
-        $result = $this->repository->getPaginatedPopulations();
+        $result = $this->repository->getPaginatedPopulations($organization->id);
 
         $this->assertEquals($newPopulation->id, $result->items()[0]->id);
         $this->assertEquals($oldPopulation->id, $result->items()[1]->id);
@@ -72,23 +78,13 @@ class DatasetSubjectPopulationRepositoryTest extends TestCase
      */
     public function test_get_paginated_populations_eager_loads_relationships(): void
     {
-        DatasetSubjectPopulation::factory()->create();
+        $organization = Organization::factory()->create();
+        DatasetSubjectPopulation::factory()->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedPopulations();
+        $result = $this->repository->getPaginatedPopulations($organization->id);
 
         $this->assertTrue($result->items()[0]->relationLoaded('dataset'));
         $this->assertTrue($result->items()[0]->relationLoaded('snapshot'));
-    }
-
-    /**
-     * Test get paginated populations returns empty when no records.
-     */
-    public function test_get_paginated_populations_returns_empty_when_no_records(): void
-    {
-        $result = $this->repository->getPaginatedPopulations();
-
-        $this->assertCount(0, $result->items());
-        $this->assertEquals(0, $result->total());
     }
 
     /**
@@ -96,10 +92,12 @@ class DatasetSubjectPopulationRepositoryTest extends TestCase
      */
     public function test_create_population_creates_new_record_with_all_fields(): void
     {
+        $organization = Organization::factory()->create();
         $dataset = Dataset::factory()->create();
         $snapshot = DatasetSnapshot::factory()->for($dataset)->create();
 
         $data = [
+            'organization_id' => $organization->id,
             'dataset_id' => $dataset->id,
             'snapshot_id' => $snapshot->id,
             'subject_realm' => SubjectRealm::CUSTOMER->value,
@@ -124,9 +122,11 @@ class DatasetSubjectPopulationRepositoryTest extends TestCase
      */
     public function test_create_population_without_snapshot_id(): void
     {
+        $organization = Organization::factory()->create();
         $dataset = Dataset::factory()->create();
 
         $data = [
+            'organization_id' => $organization->id,
             'dataset_id' => $dataset->id,
             'subject_realm' => SubjectRealm::EMPLOYEE->value,
             'jurisdiction' => Jurisdiction::US->value,
@@ -145,9 +145,11 @@ class DatasetSubjectPopulationRepositoryTest extends TestCase
      */
     public function test_create_population_auto_sets_created_at(): void
     {
+        $organization = Organization::factory()->create();
         $dataset = Dataset::factory()->create();
 
         $data = [
+            'organization_id' => $organization->id,
             'dataset_id' => $dataset->id,
             'subject_realm' => SubjectRealm::CUSTOMER->value,
             'jurisdiction' => Jurisdiction::EU->value,
@@ -233,131 +235,5 @@ class DatasetSubjectPopulationRepositoryTest extends TestCase
         $this->assertDatabaseMissing('dataset_subject_populations', [
             'id' => $population->id,
         ]);
-    }
-
-    /**
-     * Test create population with all subject realms.
-     */
-    public function test_create_population_with_all_subject_realms(): void
-    {
-        $dataset = Dataset::factory()->create();
-
-        $realms = [
-            SubjectRealm::CUSTOMER,
-            SubjectRealm::PROSPECT,
-            SubjectRealm::EMPLOYEE,
-            SubjectRealm::VENDOR,
-            SubjectRealm::OTHER,
-        ];
-
-        foreach ($realms as $realm) {
-            $data = [
-                'dataset_id' => $dataset->id,
-                'subject_realm' => $realm->value,
-                'jurisdiction' => Jurisdiction::EU->value,
-                'subjects_total' => 1000,
-                'as_of' => now(),
-            ];
-
-            $population = $this->repository->createPopulation($data);
-
-            $this->assertEquals($realm->value, $population->subject_realm);
-        }
-    }
-
-    /**
-     * Test create population with all jurisdictions.
-     */
-    public function test_create_population_with_all_jurisdictions(): void
-    {
-        $dataset = Dataset::factory()->create();
-
-        $jurisdictions = [
-            Jurisdiction::AE,
-            Jurisdiction::EU,
-            Jurisdiction::KSA,
-            Jurisdiction::US,
-            Jurisdiction::UK,
-            Jurisdiction::QA,
-            Jurisdiction::JO,
-            Jurisdiction::MA,
-            Jurisdiction::BH,
-            Jurisdiction::OTHER,
-        ];
-
-        foreach ($jurisdictions as $jurisdiction) {
-            $data = [
-                'dataset_id' => $dataset->id,
-                'subject_realm' => SubjectRealm::CUSTOMER->value,
-                'jurisdiction' => $jurisdiction->value,
-                'subjects_total' => 1000,
-                'as_of' => now(),
-            ];
-
-            $population = $this->repository->createPopulation($data);
-
-            $this->assertEquals($jurisdiction->value, $population->jurisdiction);
-        }
-    }
-
-    /**
-     * Test create population with zero subjects.
-     */
-    public function test_create_population_with_zero_subjects(): void
-    {
-        $dataset = Dataset::factory()->create();
-
-        $data = [
-            'dataset_id' => $dataset->id,
-            'subject_realm' => SubjectRealm::CUSTOMER->value,
-            'jurisdiction' => Jurisdiction::EU->value,
-            'subjects_total' => 0,
-            'as_of' => now(),
-        ];
-
-        $population = $this->repository->createPopulation($data);
-
-        $this->assertEquals(0, $population->subjects_total);
-    }
-
-    /**
-     * Test create population with large subject numbers.
-     */
-    public function test_create_population_with_large_numbers(): void
-    {
-        $dataset = Dataset::factory()->create();
-
-        $data = [
-            'dataset_id' => $dataset->id,
-            'subject_realm' => SubjectRealm::CUSTOMER->value,
-            'jurisdiction' => Jurisdiction::EU->value,
-            'subjects_total' => 50000000,
-            'as_of' => now(),
-        ];
-
-        $population = $this->repository->createPopulation($data);
-
-        $this->assertEquals(50000000, $population->subjects_total);
-    }
-
-    /**
-     * Test create population with past as_of date.
-     */
-    public function test_create_population_with_past_as_of_date(): void
-    {
-        $dataset = Dataset::factory()->create();
-        $pastDate = now()->subMonths(6);
-
-        $data = [
-            'dataset_id' => $dataset->id,
-            'subject_realm' => SubjectRealm::CUSTOMER->value,
-            'jurisdiction' => Jurisdiction::EU->value,
-            'subjects_total' => 1000,
-            'as_of' => $pastDate,
-        ];
-
-        $population = $this->repository->createPopulation($data);
-
-        $this->assertEquals($pastDate->timestamp, $population->as_of->timestamp);
     }
 }

--- a/tests/Feature/Repositories/PdpProcessingRegisterRepositoryTest.php
+++ b/tests/Feature/Repositories/PdpProcessingRegisterRepositoryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Repositories;
 
 use App\Models\PdpProcessingRegister;
+use App\Models\Organization;
 use App\Repositories\PdpProcessingRegisterRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -24,9 +25,10 @@ class PdpProcessingRegisterRepositoryTest extends TestCase
      */
     public function test_get_paginated_registers_returns_paginated_results(): void
     {
-        PdpProcessingRegister::factory()->count(20)->create();
+        $organization = Organization::factory()->create();
+        PdpProcessingRegister::factory()->count(20)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedRegisters(10);
+        $result = $this->repository->getPaginatedRegisters($organization->id, 10);
 
         $this->assertCount(10, $result->items());
         $this->assertEquals(20, $result->total());
@@ -38,9 +40,10 @@ class PdpProcessingRegisterRepositoryTest extends TestCase
      */
     public function test_get_paginated_registers_uses_default_per_page(): void
     {
-        PdpProcessingRegister::factory()->count(20)->create();
+        $organization = Organization::factory()->create();
+        PdpProcessingRegister::factory()->count(20)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedRegisters();
+        $result = $this->repository->getPaginatedRegisters($organization->id);
 
         $this->assertEquals(15, $result->perPage());
     }
@@ -50,14 +53,17 @@ class PdpProcessingRegisterRepositoryTest extends TestCase
      */
     public function test_get_paginated_registers_orders_by_created_at_desc(): void
     {
+        $organization = Organization::factory()->create();
         $oldRegister = PdpProcessingRegister::factory()->create([
             'created_at' => now()->subDays(10),
+            'organization_id' => $organization->id,
         ]);
         $newRegister = PdpProcessingRegister::factory()->create([
             'created_at' => now(),
+            'organization_id' => $organization->id,
         ]);
 
-        $result = $this->repository->getPaginatedRegisters();
+        $result = $this->repository->getPaginatedRegisters($organization->id);
 
         $this->assertEquals($newRegister->id, $result->items()[0]->id);
         $this->assertEquals($oldRegister->id, $result->items()[1]->id);
@@ -68,7 +74,8 @@ class PdpProcessingRegisterRepositoryTest extends TestCase
      */
     public function test_get_paginated_registers_returns_empty_when_no_records(): void
     {
-        $result = $this->repository->getPaginatedRegisters();
+        $organization = Organization::factory()->create();
+        $result = $this->repository->getPaginatedRegisters($organization->id);
 
         $this->assertCount(0, $result->items());
         $this->assertEquals(0, $result->total());
@@ -79,7 +86,9 @@ class PdpProcessingRegisterRepositoryTest extends TestCase
      */
     public function test_create_register_creates_new_record_with_all_fields(): void
     {
+        $organization = Organization::factory()->create();
         $data = [
+            'organization_id' => $organization->id,
             'processing_id' => 'PDP-TEST001',
             'purpose' => 'AI model training',
             'controller_role' => 'Controller',
@@ -113,7 +122,10 @@ class PdpProcessingRegisterRepositoryTest extends TestCase
      */
     public function test_create_register_with_minimal_fields(): void
     {
+        $organization = Organization::factory()->create();
+
         $data = [
+            'organization_id' => $organization->id,
             'processing_id' => 'PDP-MIN001',
             'purpose' => 'Analytics',
             'controller_role' => 'Processor',
@@ -137,6 +149,7 @@ class PdpProcessingRegisterRepositoryTest extends TestCase
      */
     public function test_create_register_with_multiple_data_subject_categories(): void
     {
+        $organization = Organization::factory()->create();
         $categories = [
             'customer',
             'prospect',
@@ -144,6 +157,7 @@ class PdpProcessingRegisterRepositoryTest extends TestCase
         ];
 
         $data = [
+            'organization_id' => $organization->id,
             'processing_id' => 'PDP-MULTI001',
             'purpose' => 'Fraud detection',
             'controller_role' => 'Controller',
@@ -234,118 +248,5 @@ class PdpProcessingRegisterRepositoryTest extends TestCase
         $this->assertDatabaseMissing('pdp_processing_registers', [
             'id' => $register->id,
         ]);
-    }
-
-    /**
-     * Test create register with all lawful bases.
-     */
-    public function test_create_register_with_all_lawful_bases(): void
-    {
-        $lawfulBases = [
-            'consent',
-            'contract',
-            'legal_obligation',
-            'legitimate_interests',
-            'public_task',
-            'vital_interests',
-        ];
-
-        foreach ($lawfulBases as $basis) {
-            $data = [
-                'purpose' => 'Testing ' . $basis,
-                'controller_role' => 'Controller',
-                'data_subject_categories' => ['customer'],
-                'personal_data_categories' => ['Identifier'],
-                'lawful_basis' => $basis,
-                'owner_team' => 'Compliance Team',
-                'status' => 'published',
-            ];
-
-            $register = $this->repository->createRegister($data);
-
-            $this->assertEquals($basis, $register->lawful_basis);
-        }
-    }
-
-    /**
-     * Test create register with all controller roles.
-     */
-    public function test_create_register_with_all_controller_roles(): void
-    {
-        $roles = ['Controller', 'Processor', 'Joint Controller'];
-
-        foreach ($roles as $role) {
-            $data = [
-                'processing_id' => 'PDP-ROLE-' . strtoupper(str_replace(' ', '', $role)),
-                'purpose' => 'Testing role',
-                'controller_role' => $role,
-                'data_subject_categories' => ['customer'],
-                'personal_data_categories' => ['Identifier'],
-                'lawful_basis' => 'consent',
-                'owner_team' => 'Data Team',
-                'status' => 'published',
-            ];
-
-            $register = $this->repository->createRegister($data);
-
-            $this->assertEquals($role, $register->controller_role);
-        }
-    }
-
-    /**
-     * Test create register with all statuses.
-     */
-    public function test_create_register_with_all_statuses(): void
-    {
-        $statuses = [
-            'draft',
-            'in_review',
-            'approved',
-            'published',
-            'archived',
-        ];
-
-        foreach ($statuses as $status) {
-            $data = [
-                'purpose' => 'Testing status',
-                'controller_role' => 'Controller',
-                'data_subject_categories' => ['customer'],
-                'personal_data_categories' => ['Identifier'],
-                'lawful_basis' => 'consent',
-                'owner_team' => 'Data Team',
-                'status' => $status,
-            ];
-
-            $register = $this->repository->createRegister($data);
-
-            $this->assertEquals($status, $register->status);
-        }
-    }
-
-    /**
-     * Test create register with effective dates.
-     */
-    public function test_create_register_with_effective_dates(): void
-    {
-        $effectiveFrom = now()->subMonth();
-        $effectiveTo = now()->addYear();
-
-        $data = [
-            'processing_id' => 'PDP-DATES001',
-            'purpose' => 'Testing dates',
-            'controller_role' => 'Controller',
-            'data_subject_categories' => ['customer'],
-            'personal_data_categories' => ['Identifier'],
-            'lawful_basis' => 'consent',
-            'owner_team' => 'Data Team',
-            'effective_from' => $effectiveFrom,
-            'effective_to' => $effectiveTo,
-            'status' => 'published',
-        ];
-
-        $register = $this->repository->createRegister($data);
-
-        $this->assertEquals($effectiveFrom->timestamp, $register->effective_from->timestamp);
-        $this->assertEquals($effectiveTo->timestamp, $register->effective_to->timestamp);
     }
 }

--- a/tests/Feature/Repositories/StakeholderRepositoryTest.php
+++ b/tests/Feature/Repositories/StakeholderRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Repositories;
 
 use App\Models\Stakeholder;
 use App\Repositories\StakeholderRepository;
+use App\Models\Organization;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -37,6 +38,16 @@ class StakeholderRepositoryTest extends TestCase
 
         $this->assertCount(5, $result->items());
         $this->assertEquals(10, $result->perPage());
+    }
+
+    public function test_get_filtered_stakeholders_with_organization_id(): void
+    {
+        $organization = Organization::factory()->create();
+        Stakeholder::factory()->count(8)->create(['organization_id' => $organization->id]);
+
+        $result = $this->repository->getFilteredStakeholders(['organization_id' => $organization->id]);
+
+        $this->assertCount(8, $result->items());
     }
 
     public function test_search_by_display_name(): void
@@ -229,6 +240,7 @@ class StakeholderRepositoryTest extends TestCase
     public function test_create_stores_stakeholder(): void
     {
         $data = [
+            'organization_id' => Organization::factory()->create()->id,
             'type' => 'internal',
             'display_name' => 'John Smith',
             'legal_name' => 'Tech Company',

--- a/tests/Feature/Repositories/UseCaseRepositoryTest.php
+++ b/tests/Feature/Repositories/UseCaseRepositoryTest.php
@@ -12,6 +12,7 @@ use App\Enums\UseCase\ROIClassification;
 use App\Enums\UseCase\Status;
 use App\Models\Stakeholder;
 use App\Models\UseCase;
+use App\Models\Organization;
 use App\Repositories\UseCaseRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
@@ -31,9 +32,10 @@ class UseCaseRepositoryTest extends TestCase
 
     public function test_it_gets_filtered_use_cases(): void
     {
-        UseCase::factory()->create(['name' => 'Test Use Case 1', 'status' => Status::ACTIVE->value]);
-        UseCase::factory()->create(['name' => 'Another Use Case', 'status' => Status::SUSPENDED->value]);
-        UseCase::factory()->create(['name' => 'Test Use Case 2', 'status' => Status::ACTIVE->value]);
+        $organization = Organization::factory()->create();
+        UseCase::factory()->create(['name' => 'Test Use Case 1', 'status' => Status::ACTIVE->value, 'organization_id' => $organization->id]);
+        UseCase::factory()->create(['name' => 'Another Use Case', 'status' => Status::SUSPENDED->value, 'organization_id' => $organization->id]);
+        UseCase::factory()->create(['name' => 'Test Use Case 2', 'status' => Status::ACTIVE->value, 'organization_id' => $organization->id]);
 
         $filters = ['name' => 'Test', 'status' => Status::ACTIVE->value, 'per_page' => 2];
         $result = $this->useCaseRepository->getFilteredUseCases($filters);
@@ -47,10 +49,12 @@ class UseCaseRepositoryTest extends TestCase
 
     public function test_it_creates_use_case(): void
     {
+        $organization = Organization::factory()->create();
         $businessOwner = Stakeholder::factory()->create();
         $technicalOwner = Stakeholder::factory()->create();
 
         $data = [
+            'organization_id' => $organization->id,
             'name' => 'New AI Use Case',
             'description' => 'This is a detailed description of the new AI use case. It provides comprehensive information about what the use case aims to achieve and how it will be implemented in the organization.',
             'business_objective' => 'To improve operational efficiency and reduce costs by automating repetitive tasks.',
@@ -102,6 +106,7 @@ class UseCaseRepositoryTest extends TestCase
     public function test_it_creates_use_case_with_minimal_required_fields(): void
     {
         $data = [
+            'organization_id' => Organization::factory()->create()->id,
             'name' => 'Minimal Use Case',
             'description' => 'This is a minimal but valid description that meets the minimum length requirement of 100 characters for testing purposes.',
             'business_objective' => 'To test minimal field creation with valid objective length.',

--- a/tests/Feature/Repositories/UserConsentRepositoryTest.php
+++ b/tests/Feature/Repositories/UserConsentRepositoryTest.php
@@ -8,6 +8,7 @@ use App\Enums\UserConsent\Jurisdiction;
 use App\Enums\UserConsent\LegalBasis;
 use App\Enums\UserConsent\SubjectRealm;
 use App\Models\UserConsent;
+use App\Models\Organization;
 use App\Repositories\UserConsentRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -29,9 +30,10 @@ class UserConsentRepositoryTest extends TestCase
      */
     public function test_get_paginated_consents_returns_paginator(): void
     {
-        UserConsent::factory()->count(5)->create();
+        $organization = Organization::factory()->create();
+        UserConsent::factory()->count(5)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedConsents();
+        $result = $this->repository->getPaginatedConsents($organization->id);
 
         $this->assertInstanceOf(\Illuminate\Contracts\Pagination\LengthAwarePaginator::class, $result);
         $this->assertEquals(5, $result->total());
@@ -42,9 +44,10 @@ class UserConsentRepositoryTest extends TestCase
      */
     public function test_get_paginated_consents_respects_per_page(): void
     {
-        UserConsent::factory()->count(20)->create();
+        $organization = Organization::factory()->create();
+        UserConsent::factory()->count(20)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedConsents(10);
+        $result = $this->repository->getPaginatedConsents($organization->id, 10);
 
         $this->assertEquals(10, $result->perPage());
         $this->assertCount(10, $result->items());
@@ -56,9 +59,10 @@ class UserConsentRepositoryTest extends TestCase
      */
     public function test_get_paginated_consents_uses_default_per_page(): void
     {
-        UserConsent::factory()->count(20)->create();
+        $organization = Organization::factory()->create();
+        UserConsent::factory()->count(20)->create(['organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedConsents();
+        $result = $this->repository->getPaginatedConsents($organization->id);
 
         $this->assertEquals(15, $result->perPage());
     }
@@ -68,11 +72,12 @@ class UserConsentRepositoryTest extends TestCase
      */
     public function test_get_paginated_consents_ordered_by_created_at_desc(): void
     {
-        $consent1 = UserConsent::factory()->create(['created_at' => now()->subDays(3)]);
-        $consent2 = UserConsent::factory()->create(['created_at' => now()->subDays(1)]);
-        $consent3 = UserConsent::factory()->create(['created_at' => now()->subDays(2)]);
+        $organization = Organization::factory()->create();
+        $consent1 = UserConsent::factory()->create(['created_at' => now()->subDays(3), 'organization_id' => $organization->id]);
+        $consent2 = UserConsent::factory()->create(['created_at' => now()->subDays(1), 'organization_id' => $organization->id]);
+        $consent3 = UserConsent::factory()->create(['created_at' => now()->subDays(2), 'organization_id' => $organization->id]);
 
-        $result = $this->repository->getPaginatedConsents();
+        $result = $this->repository->getPaginatedConsents($organization->id);
 
         $this->assertEquals($consent2->id, $result->items()[0]->id);
         $this->assertEquals($consent3->id, $result->items()[1]->id);
@@ -108,7 +113,9 @@ class UserConsentRepositoryTest extends TestCase
      */
     public function test_create_consent_creates_new_consent(): void
     {
+        $organization = Organization::factory()->create();
         $data = [
+            'organization_id' => $organization->id,
             'subject_key' => 'SUBJ-123456',
             'subject_realm' => SubjectRealm::CUSTOMER,
             'jurisdiction' => Jurisdiction::EU,
@@ -141,7 +148,9 @@ class UserConsentRepositoryTest extends TestCase
      */
     public function test_create_consent_with_minimal_data(): void
     {
+        $organization = Organization::factory()->create();
         $data = [
+            'organization_id' => $organization->id,
             'subject_key' => 'SUBJ-789',
             'subject_realm' => SubjectRealm::PROSPECT,
             'jurisdiction' => Jurisdiction::US,
@@ -165,6 +174,7 @@ class UserConsentRepositoryTest extends TestCase
      */
     public function test_create_consent_with_multiple_purposes(): void
     {
+        $organization = Organization::factory()->create();
         $purposes = [
             ConsentPurpose::MARKETING->value,
             ConsentPurpose::ANALYTICS->value,
@@ -173,6 +183,7 @@ class UserConsentRepositoryTest extends TestCase
         ];
 
         $data = [
+            'organization_id' => $organization->id,
             'subject_key' => 'SUBJ-MULTI',
             'subject_realm' => SubjectRealm::CUSTOMER,
             'jurisdiction' => Jurisdiction::EU,


### PR DESCRIPTION
- Updated DataSourceRepositoryTest to create DataSource instances with organization_id.
- Modified DatasetRepositoryTest to ensure Dataset instances are associated with an organization.
- Adjusted DatasetSnapshotRepositoryTest to include organization_id when creating DatasetSnapshot instances.
- Enhanced DatasetSubjectPopulationRepositoryTest to create DatasetSubjectPopulation with organization_id.
- Updated PdpProcessingRegisterRepositoryTest to ensure PdpProcessingRegister instances are linked to an organization.
- Refined StakeholderRepositoryTest to include organization_id in stakeholder creation and filtering.
- Adjusted UseCaseRepositoryTest to create UseCase instances with organization_id.
- Updated UserConsentRepositoryTest to ensure UserConsent instances are associated with an organization.