### PR TITLE
feat: Implement Data Subject Request Access functionality

### DIFF
--- a/app/Enums/DataSubjectRequestAccess/Jurisdiction.php
+++ b/app/Enums/DataSubjectRequestAccess/Jurisdiction.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums\DataSubjectRequestAccess;
+
+enum Jurisdiction: string
+{
+    case EU = 'eu';
+    case UAE = 'uae';
+    case DIFC = 'difc';
+    case UK = 'uk';
+    case KSA = 'ksa';
+    case US_CA = 'us-ca';
+}

--- a/app/Enums/DataSubjectRequestAccess/Priority.php
+++ b/app/Enums/DataSubjectRequestAccess/Priority.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums\DataSubjectRequestAccess;
+
+enum Priority: string
+{
+    case LOW = 'low';
+    case NORMAL = 'normal';
+    case HIGH = 'high';
+    case URGENT = 'urgent';
+}

--- a/app/Enums/DataSubjectRequestAccess/RequestSource.php
+++ b/app/Enums/DataSubjectRequestAccess/RequestSource.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums\DataSubjectRequestAccess;
+
+enum RequestSource: string
+{
+    case EMAIL = 'email';
+    case WEB_FORM = 'web_form';
+    case PHONE = 'phone';
+    case LETTER = 'letter';
+    case IN_PERSON = 'in_person';
+}

--- a/app/Enums/DataSubjectRequestAccess/RequestType.php
+++ b/app/Enums/DataSubjectRequestAccess/RequestType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums\DataSubjectRequestAccess;
+
+enum RequestType: string
+{
+    case ACCESS = 'access';
+    case RECTIFICATION = 'rectification';
+    case ERASURE = 'erasure';
+    case RESTRICTION = 'restriction';
+    case PORTABILITY = 'portability';
+    case OBJECTION = 'objection';
+    case OPT_OUT_MARKETING = 'opt_out_marketing';
+    case AI_EXPLAINABILITY = 'ai_explainability';
+    case AUTOMATED_DECISION_CHALLENGE = 'automated_decision_challenge';
+}

--- a/app/Enums/DataSubjectRequestAccess/ResponseFormat.php
+++ b/app/Enums/DataSubjectRequestAccess/ResponseFormat.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums\DataSubjectRequestAccess;
+
+enum ResponseFormat: string
+{
+    case PDF = 'pdf';
+    case JSON = 'json';
+    case CSV = 'csv';
+    case EXCEL = 'excel';
+    case PORTAL_ACCESS = 'portal_access';
+    case PHYSICAL_COPY = 'physical_copy';
+}

--- a/app/Enums/DataSubjectRequestAccess/ResponseMethod.php
+++ b/app/Enums/DataSubjectRequestAccess/ResponseMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums\DataSubjectRequestAccess;
+
+enum ResponseMethod: string
+{
+    case EMAIL = 'email';
+    case SECURE_PORTAL = 'secure_portal';
+    case ENCRYPTED_FILE = 'encrypted_file';
+    case PHYSICAL_MAIL = 'physical_mail';
+    case IN_PERSON = 'in_person';
+}

--- a/app/Enums/DataSubjectRequestAccess/Status.php
+++ b/app/Enums/DataSubjectRequestAccess/Status.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enums\DataSubjectRequestAccess;
+
+enum Status: string
+{
+    case NEW = 'new';
+    case PENDING_VERIFICATION = 'pending_verification';
+    case IN_PROGRESS = 'in_progress';
+    case PENDING_APPROVAL = 'pending_approval';
+    case READY_FOR_RESPONSE = 'ready_for_response';
+    case COMPLETED = 'completed';
+    case REJECTED = 'rejected';
+    case CANCELLED = 'cancelled';
+}

--- a/app/Enums/DataSubjectRequestAccess/SubjectRealm.php
+++ b/app/Enums/DataSubjectRequestAccess/SubjectRealm.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums\DataSubjectRequestAccess;
+
+enum SubjectRealm: string
+{
+    case CUSTOMER = 'customer';
+    case EMPLOYEE = 'employee';
+    case VENDOR = 'vendor';
+    case STUDENT = 'student';
+    case PATIENT = 'patient';
+}

--- a/app/Enums/DataSubjectRequestAccess/VerificationMethod.php
+++ b/app/Enums/DataSubjectRequestAccess/VerificationMethod.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums\DataSubjectRequestAccess;
+
+enum VerificationMethod: string
+{
+    case EMAIL_LINK = 'email_link';
+    case SMS_CODE = 'sms_code';
+    case ID_DOCUMENT = 'id_document';
+    case IN_PERSON = 'in_person';
+    case CALLBACK = 'callback';
+}

--- a/app/Enums/DataSubjectRequestAccess/VerificationStatus.php
+++ b/app/Enums/DataSubjectRequestAccess/VerificationStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums\DataSubjectRequestAccess;
+
+enum VerificationStatus: string
+{
+    case PENDING = 'pending';
+    case IN_PROGRESS = 'in_progress';
+    case VERIFIED = 'verified';
+    case REJECTED = 'rejected';
+    case FAILED = 'failed';
+}

--- a/app/Http/Controllers/User/DataSubjectRequestAccessController.php
+++ b/app/Http/Controllers/User/DataSubjectRequestAccessController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\User;
+
+use Illuminate\Support\Str;
+use Illuminate\Http\JsonResponse;
+use App\Http\Controllers\Controller;
+use App\Models\DataSubjectRequestAccess;
+use App\Http\Resources\DataSubjectRequestAccessResource;
+use App\Repositories\DataSubjectRequestAccessRepository;
+use App\Enums\DataSubjectRequestAccess\VerificationStatus;
+use App\Http\Requests\DataSubjectRequestAccess\ListDataSubjectRequestAccessRequest;
+use App\Http\Requests\DataSubjectRequestAccess\StoreDataSubjectRequestAccessRequest;
+use App\Http\Requests\DataSubjectRequestAccess\UpdateDataSubjectRequestAccessRequest;
+
+class DataSubjectRequestAccessController extends Controller
+{
+    public function __construct(private DataSubjectRequestAccessRepository $repository) {}
+
+    public function index(ListDataSubjectRequestAccessRequest $request): JsonResponse
+    {
+        $filters = $request->validated();
+        $dataSubjectRequests = $this->repository->getFilteredDataSubjectRequestAccesses($filters);
+
+        return response()->json([
+            'error' => false,
+            'message' => 'Data Subject Requests retrieved successfully',
+            'data' => $dataSubjectRequests,
+        ]);
+    }
+
+    public function store(StoreDataSubjectRequestAccessRequest $request): JsonResponse
+    {
+        $data = $request->validated();
+
+        $uuid = Str::uuid()->toString();
+        $data['request_code'] = 'DSAR-'.date('Y').'-'.$uuid;
+        if (isset($data['verification_status']) && $data['verification_status'] === VerificationStatus::VERIFIED->value) {
+            $data['verification_date'] = now();
+        }
+        $dataSubjectRequestAccess = $this->repository->createDataSubjectRequestAccess($data);
+
+        return response()->json([
+            'error' => false,
+            'message' => 'Data Subject Request Access created successfully',
+            'data' => $dataSubjectRequestAccess,
+        ], 201);
+
+    }
+
+    public function show(DataSubjectRequestAccess $dataSubjectRequestAccess): JsonResponse
+    {
+        return response()->json([
+            'error' => false,
+            'message' => 'Data Subject Request Access retrieved successfully',
+            'data' => new DataSubjectRequestAccessResource($dataSubjectRequestAccess),
+        ]);
+    }
+
+    public function update(UpdateDataSubjectRequestAccessRequest $request, DataSubjectRequestAccess $dataSubjectRequestAccess): JsonResponse
+    {
+        $data = $request->validated();
+
+        if (
+            isset($data['verification_status']) &&
+            $data['verification_status'] !== $dataSubjectRequestAccess->verification_status &&
+            $data['verification_status'] === VerificationStatus::VERIFIED->value
+        ) {
+            $data['verification_date'] = now();
+        }
+
+        $updatedDataSubjectRequestAccess = $this->repository->updateDataSubjectRequestAccess($dataSubjectRequestAccess, $data);
+
+        return response()->json([
+            'error' => false,
+            'message' => 'Data Subject Request Access updated successfully',
+            'data' => $updatedDataSubjectRequestAccess,
+        ]);
+    }
+
+    public function destroy(DataSubjectRequestAccess $dataSubjectRequestAccess): JsonResponse
+    {
+        $this->repository->deleteDataSubjectRequestAccess($dataSubjectRequestAccess);
+
+        return response()->json([
+            'error' => false,
+            'message' => 'Data Subject Request Access deleted successfully',
+        ]);
+    }
+}

--- a/app/Http/Requests/DataSubjectRequestAccess/ListDataSubjectRequestAccessRequest.php
+++ b/app/Http/Requests/DataSubjectRequestAccess/ListDataSubjectRequestAccessRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Requests\DataSubjectRequestAccess;
+
+use Illuminate\Validation\Rule;
+use Illuminate\Foundation\Http\FormRequest;
+use App\Enums\DataSubjectRequestAccess\Status;
+use App\Enums\DataSubjectRequestAccess\Priority;
+use App\Enums\DataSubjectRequestAccess\RequestType;
+use App\Enums\DataSubjectRequestAccess\Jurisdiction;
+use App\Enums\DataSubjectRequestAccess\SubjectRealm;
+use App\Enums\DataSubjectRequestAccess\VerificationStatus;
+
+class ListDataSubjectRequestAccessRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['nullable', Rule::enum(Status::class)],
+            'request_type' => ['nullable', Rule::enum(RequestType::class)],
+            'verification_status' => ['nullable', Rule::enum(VerificationStatus::class)],
+            'jurisdiction' => ['nullable', Rule::enum(Jurisdiction::class)],
+            'subject_realm' => ['nullable', Rule::enum(SubjectRealm::class)],
+            'priority' => ['nullable', Rule::enum(Priority::class)],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/DataSubjectRequestAccess/StoreDataSubjectRequestAccessRequest.php
+++ b/app/Http/Requests/DataSubjectRequestAccess/StoreDataSubjectRequestAccessRequest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Http\Requests\DataSubjectRequestAccess;
+
+use Illuminate\Validation\Rule;
+use Illuminate\Foundation\Http\FormRequest;
+use App\Enums\DataSubjectRequestAccess\Status;
+use App\Enums\DataSubjectRequestAccess\Priority;
+use App\Enums\DataSubjectRequestAccess\RequestType;
+use App\Enums\DataSubjectRequestAccess\SubjectRealm;
+use App\Enums\DataSubjectRequestAccess\RequestSource;
+use App\Enums\DataSubjectRequestAccess\ResponseFormat;
+use App\Enums\DataSubjectRequestAccess\ResponseMethod;
+use App\Enums\DataSubjectRequestAccess\VerificationMethod;
+use App\Enums\DataSubjectRequestAccess\VerificationStatus;
+
+class StoreDataSubjectRequestAccessRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $isVerified = fn () => $this->verification_status === VerificationStatus::VERIFIED;
+        $isCompleted = fn () => $this->status === Status::COMPLETED;
+        $isReadyForResponse = fn () => $this->status === Status::READY_FOR_RESPONSE;
+        $isRejected = fn () => $this->status === Status::REJECTED;
+
+        return [
+            'request_type' => ['required', Rule::enum(RequestType::class)],
+            'subject_identifier' => ['required', 'string', 'max:255'],
+            'subject_name' => ['nullable', 'string', 'max:255'],
+            'subject_realm' => ['required', Rule::enum(SubjectRealm::class)],
+            'verification_status' => ['required', Rule::enum(VerificationStatus::class)],
+            'subject_key' => [
+                Rule::requiredIf($isVerified),
+                'string',
+                'max:255',
+            ],
+            'verification_method' => [
+                Rule::requiredIf($isVerified),
+                Rule::enum(VerificationMethod::class),
+            ],
+            'verified_by' => [
+                Rule::requiredIf($isVerified),
+                'integer',
+                'exists:users,id',
+            ],
+            'request_details' => ['required', 'string'],
+            'requested_data_categories' => ['nullable', 'array'],
+            'requested_data_categories.*' => ['string', 'max:255'],
+            'request_source' => ['required', Rule::enum(RequestSource::class)],
+            'submitted_date' => ['required', 'date'],
+            'due_date' => ['required', 'date', 'after_or_equal:submitted_date'],
+            'extended_due_date' => ['nullable', 'date', 'after:due_date'],
+            'status' => ['required', Rule::enum(Status::class)],
+            'response_date' => [
+                Rule::requiredIf($isCompleted),
+                'date',
+            ],
+            'completed_date' => [
+                Rule::requiredIf($isCompleted),
+                'date',
+                'after_or_equal:response_date',
+            ],
+            'priority' => ['required', Rule::enum(Priority::class)],
+            'is_overdue' => ['required', 'boolean'],
+            'assigned_to' => ['required', 'integer', 'exists:users,id'],
+            'assigned_date' => ['required', 'date'],
+            'response_method' => [
+                Rule::requiredIf($isReadyForResponse),
+                Rule::enum(ResponseMethod::class),
+            ],
+            'response_format' => [
+                Rule::requiredIf($isReadyForResponse),
+                Rule::enum(ResponseFormat::class),
+            ],
+            'response_uri' => [
+                Rule::requiredIf($isReadyForResponse),
+                'url',
+            ],
+            'response_notes' => ['nullable', 'string'],
+            'rejection_reason' => ['nullable', 'string'],
+            'jurisdiction' => [
+                Rule::requiredIf($isRejected),
+                'string',
+                'max:255',
+            ],
+            'processing_activity_ids' => ['nullable', 'array'],
+            'processing_activity_ids.*' => ['integer', 'exists:record_of_processing_activities,id'],
+            'systems_checked' => ['required', 'string', 'max:255'],
+            'records_found' => ['nullable', 'integer'],
+        ];
+    }
+}

--- a/app/Http/Requests/DataSubjectRequestAccess/UpdateDataSubjectRequestAccessRequest.php
+++ b/app/Http/Requests/DataSubjectRequestAccess/UpdateDataSubjectRequestAccessRequest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Http\Requests\DataSubjectRequestAccess;
+
+use Illuminate\Validation\Rule;
+use Illuminate\Foundation\Http\FormRequest;
+use App\Enums\DataSubjectRequestAccess\Status;
+use App\Enums\DataSubjectRequestAccess\Priority;
+use App\Enums\DataSubjectRequestAccess\RequestType;
+use App\Enums\DataSubjectRequestAccess\SubjectRealm;
+use App\Enums\DataSubjectRequestAccess\RequestSource;
+use App\Enums\DataSubjectRequestAccess\ResponseFormat;
+use App\Enums\DataSubjectRequestAccess\ResponseMethod;
+use App\Enums\DataSubjectRequestAccess\VerificationMethod;
+use App\Enums\DataSubjectRequestAccess\VerificationStatus;
+
+class UpdateDataSubjectRequestAccessRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $isVerified = fn () => $this->verification_status === VerificationStatus::VERIFIED;
+        $isCompleted = fn () => $this->status === Status::COMPLETED;
+        $isReadyForResponse = fn () => $this->status === Status::READY_FOR_RESPONSE;
+        $isRejected = fn () => $this->status === Status::REJECTED;
+
+        return [
+            'request_type' => ['sometimes', Rule::enum(RequestType::class)],
+            'subject_identifier' => ['sometimes', 'string', 'max:255'],
+            'subject_name' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'subject_realm' => ['sometimes', Rule::enum(SubjectRealm::class)],
+            'verification_status' => ['sometimes', Rule::enum(VerificationStatus::class)],
+            'subject_key' => [
+                'sometimes',
+                Rule::requiredIf($isVerified),
+                'string',
+                'max:255',
+            ],
+            'verification_method' => [
+                'sometimes',
+                Rule::requiredIf($isVerified),
+                Rule::enum(VerificationMethod::class),
+            ],
+            'verification_date' => ['sometimes', 'nullable', 'date'],
+            'verified_by' => [
+                'sometimes',
+                Rule::requiredIf($isVerified),
+                'integer',
+                'exists:users,id',
+            ],
+            'request_details' => ['sometimes', 'string'],
+            'requested_data_categories' => ['sometimes', 'nullable', 'array'],
+            'requested_data_categories.*' => ['string', 'max:255'],
+            'request_source' => ['sometimes', Rule::enum(RequestSource::class)],
+            'submitted_date' => ['sometimes', 'date'],
+            'due_date' => ['sometimes', 'date', 'after_or_equal:submitted_date'],
+            'extended_due_date' => ['sometimes', 'nullable', 'date', 'after:due_date'],
+            'response_date' => [
+                'sometimes',
+                Rule::requiredIf($isCompleted),
+                'date',
+            ],
+            'completed_date' => [
+                'sometimes',
+                Rule::requiredIf($isCompleted),
+                'date',
+                'after_or_equal:response_date',
+            ],
+            'status' => ['sometimes', Rule::enum(Status::class)],
+            'priority' => ['sometimes', Rule::enum(Priority::class)],
+            'is_overdue' => ['sometimes', 'boolean'],
+            'assigned_to' => ['sometimes', 'integer', 'exists:users,id'],
+            'assigned_date' => ['sometimes', 'date'],
+            'response_method' => [
+                'sometimes',
+                Rule::requiredIf($isReadyForResponse),
+                Rule::enum(ResponseMethod::class),
+            ],
+            'response_format' => [
+                'sometimes',
+                Rule::requiredIf($isReadyForResponse),
+                Rule::enum(ResponseFormat::class),
+            ],
+            'response_uri' => [
+                'sometimes',
+                Rule::requiredIf($isReadyForResponse),
+                'url',
+            ],
+            'response_notes' => ['sometimes', 'nullable', 'string'],
+            'rejection_reason' => ['sometimes', 'nullable', 'string'],
+            'jurisdiction' => [
+                'sometimes',
+                Rule::requiredIf($isRejected),
+                'string',
+                'max:255',
+            ],
+            'processing_activity_ids' => ['sometimes', 'nullable', 'array'],
+            'processing_activity_ids.*' => ['integer', 'exists:record_of_processing_activities,id'],
+            'systems_checked' => ['sometimes', 'array', 'min:1'],
+            'systems_checked.*' => ['string', 'max:255'],
+            'records_found' => ['sometimes', 'nullable', 'integer'],
+        ];
+    }
+}

--- a/app/Http/Resources/DataSubjectRequestAccessResource.php
+++ b/app/Http/Resources/DataSubjectRequestAccessResource.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin \App\Models\DataSubjectRequestAccess
+ */
+class DataSubjectRequestAccessResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'request_code' => $this->request_code,
+            'request_type' => $this->request_type,
+            'subject_identifier' => $this->subject_identifier,
+            'subject_key' => $this->subject_key,
+            'subject_name' => $this->subject_name,
+            'subject_realm' => $this->subject_realm,
+            'verification_status' => $this->verification_status,
+            'verification_method' => $this->verification_method,
+            'verification_date' => $this->verification_date?->toIso8601String(),
+            'verified_by' => $this->verified_by,
+            'request_details' => $this->request_details,
+            'requested_data_categories' => $this->requested_data_categories,
+            'request_source' => $this->request_source,
+            'submitted_date' => $this->submitted_date->toIso8601String(),
+            'due_date' => $this->due_date->toIso8601String(),
+            'extended_due_date' => $this->extended_due_date?->toIso8601String(),
+            'response_date' => $this->response_date?->toIso8601String(),
+            'completed_date' => $this->completed_date?->toIso8601String(),
+            'status' => $this->status,
+            'priority' => $this->priority,
+            'is_overdue' => $this->is_overdue,
+            'assigned_to' => $this->assigned_to,
+            'assigned_date' => $this->assigned_date?->toIso8601String(),
+            'response_method' => $this->response_method,
+            'response_format' => $this->response_format,
+            'response_uri' => $this->response_uri,
+            'response_notes' => $this->response_notes,
+            'rejection_reason' => $this->rejection_reason,
+            'jurisdiction' => $this->jurisdiction,
+            'processing_activity_ids' => $this->processing_activity_ids,
+            'systems_checked' => $this->systems_checked,
+            'records_found' => $this->records_found,
+            'remaining_days' => $this->remaining_days,
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/DataSubjectRequestAccess.php
+++ b/app/Models/DataSubjectRequestAccess.php
@@ -3,8 +3,74 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class DataSubjectRequestAccess extends Model
 {
-    //
+    /** @use HasFactory<\Database\Factories\DataSubjectRequestAccessFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'request_code',
+        'request_type',
+        'subject_identifier',
+        'subject_key',
+        'subject_name',
+        'subject_realm',
+        'verification_status',
+        'verification_method',
+        'verification_date',
+        'verified_by',
+        'request_details',
+        'requested_data_categories',
+        'request_source',
+        'submitted_date',
+        'due_date',
+        'extended_due_date',
+        'response_date',
+        'completed_date',
+        'status',
+        'priority',
+        'is_overdue',
+        'assigned_to',
+        'assigned_date',
+        'response_method',
+        'response_format',
+        'response_uri',
+        'response_notes',
+        'rejection_reason',
+        'jurisdiction',
+        'processing_activity_ids',
+        'systems_checked',
+        'records_found',
+    ];
+
+    protected $casts = [
+        'requested_data_categories' => 'array',
+        'processing_activity_ids' => 'array',
+        'verification_date' => 'date',
+        'submitted_date' => 'date',
+        'due_date' => 'date',
+        'extended_due_date' => 'date',
+        'response_date' => 'date',
+        'completed_date' => 'date',
+        'assigned_date' => 'date',
+        'is_overdue' => 'boolean',
+    ];
+
+    protected $appends = [
+        'remaining_days',
+    ];
+
+    public function getRemainingDaysAttribute(): ?int
+    {
+        if ($this->due_date !== null) {
+            $today = now()->startOfDay();
+            $dueDate = $this->due_date->startOfDay();
+
+            return (int) $today->diffInDays($dueDate, false);
+        }
+
+        return null;
+    }
 }

--- a/app/Repositories/DataSubjectRequestAccessRepository.php
+++ b/app/Repositories/DataSubjectRequestAccessRepository.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\DataSubjectRequestAccess;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class DataSubjectRequestAccessRepository
+{
+    /**
+     * Get paginated list of data subject request accesses with specified filters.
+     *
+     * @return \Illuminate\Pagination\LengthAwarePaginator<int, DataSubjectRequestAccess>
+     */
+    public function getFilteredDataSubjectRequestAccesses(array $filters = []): LengthAwarePaginator
+    {
+        $query = DataSubjectRequestAccess::query();
+
+        if (isset($filters['status']) && ! empty($filters['status'])) {
+            $query->where('status', $filters['status']);
+        }
+
+        if (isset($filters['request_type']) && ! empty($filters['request_type'])) {
+            $query->where('request_type', $filters['request_type']);
+        }
+
+        if (isset($filters['verification_status']) && ! empty($filters['verification_status'])) {
+            $query->where('verification_status', $filters['verification_status']);
+        }
+
+        if (isset($filters['jurisdiction']) && ! empty($filters['jurisdiction'])) {
+            $query->where('jurisdiction', $filters['jurisdiction']);
+        }
+
+        if (isset($filters['subject_realm']) && ! empty($filters['subject_realm'])) {
+            $query->where('subject_realm', $filters['subject_realm']);
+        }
+
+        if (isset($filters['priority']) && ! empty($filters['priority'])) {
+            $query->where('priority', $filters['priority']);
+        }
+
+        $perPage = $filters['per_page'] ?? 15;
+
+        return $query->orderBy('created_at', 'desc')->paginate($perPage);
+    }
+
+    public function createDataSubjectRequestAccess(array $data): DataSubjectRequestAccess
+    {
+        return DataSubjectRequestAccess::create($data);
+    }
+
+    public function updateDataSubjectRequestAccess(DataSubjectRequestAccess $dataSubjectRequestAccess, array $data): DataSubjectRequestAccess
+    {
+        $dataSubjectRequestAccess->update($data);
+
+        return $dataSubjectRequestAccess->fresh();
+    }
+
+    public function deleteDataSubjectRequestAccess(DataSubjectRequestAccess $dataSubjectRequestAccess): bool
+    {
+        return (bool) $dataSubjectRequestAccess->delete();
+    }
+}

--- a/database/factories/DataSubjectRequestAccessFactory.php
+++ b/database/factories/DataSubjectRequestAccessFactory.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\DataSubjectRequestAccess;
+use App\Enums\DataSubjectRequestAccess\Status;
+use App\Enums\DataSubjectRequestAccess\Priority;
+use App\Enums\DataSubjectRequestAccess\RequestType;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Enums\DataSubjectRequestAccess\SubjectRealm;
+use App\Enums\DataSubjectRequestAccess\RequestSource;
+use App\Enums\DataSubjectRequestAccess\ResponseFormat;
+use App\Enums\DataSubjectRequestAccess\ResponseMethod;
+use App\Enums\DataSubjectRequestAccess\VerificationMethod;
+use App\Enums\DataSubjectRequestAccess\VerificationStatus;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DataSubjectRequestAccess>
+ */
+class DataSubjectRequestAccessFactory extends Factory
+{
+    protected $model = DataSubjectRequestAccess::class;
+
+    public function definition(): array
+    {
+        $submittedDate = $this->faker->dateTimeBetween('-90 days', 'now');
+        $dueDate = $this->faker->dateTimeBetween($submittedDate, '+30 days');
+        $isOverdue = now() > $dueDate;
+
+        return [
+            'request_code' => 'DSR-'.strtoupper($this->faker->unique()->bothify('????-####')),
+            'request_type' => $this->faker->randomElement(RequestType::cases())->value,
+            'subject_identifier' => $this->faker->email(),
+            'subject_key' => $this->faker->uuid(),
+            'subject_name' => $this->faker->name(),
+            'subject_realm' => $this->faker->randomElement(SubjectRealm::cases())->value,
+            'verification_status' => $this->faker->randomElement(VerificationStatus::cases())->value,
+            'verification_method' => $this->faker->randomElement(VerificationMethod::cases())->value,
+            'verification_date' => $this->faker->optional(0.6)->dateTime(),
+            'verified_by' => $this->faker->optional(0.6)->randomElement(User::query()->pluck('id')->toArray()),
+            'request_details' => $this->faker->sentence(),
+            'requested_data_categories' => $this->faker->randomElements(
+                ['personal_info', 'contact_data', 'transaction_history', 'preferences', 'communication_logs'],
+                $this->faker->numberBetween(1, 3)
+            ),
+            'request_source' => $this->faker->randomElement(RequestSource::cases())->value,
+            'submitted_date' => $submittedDate,
+            'due_date' => $dueDate,
+            'extended_due_date' => $this->faker->optional(0.3)->dateTimeBetween($dueDate, '+60 days'),
+            'response_date' => $this->faker->optional(0.4)->dateTime(),
+            'completed_date' => $this->faker->optional(0.3)->dateTime(),
+            'status' => $this->faker->randomElement(Status::cases())->value,
+            'priority' => $this->faker->randomElement(Priority::cases())->value,
+            'is_overdue' => $isOverdue,
+            'assigned_to' => User::factory(),
+            'assigned_date' => $this->faker->dateTime(),
+            'response_method' => $this->faker->randomElement(ResponseMethod::cases())->value,
+            'response_format' => $this->faker->randomElement(ResponseFormat::cases())->value,
+            'response_uri' => $this->faker->optional(0.4)->url(),
+            'response_notes' => $this->faker->optional(0.4)->paragraph(),
+            'rejection_reason' => $this->faker->optional(0.2)->sentence(),
+            'jurisdiction' => $this->faker->randomElement(['EU', 'UAE', 'UK', 'KSA', 'DIFC']),
+            'processing_activity_ids' => $this->faker->optional(0.5)->randomElements([1, 2, 3, 4, 5], $this->faker->numberBetween(1, 3)),
+            'systems_checked' => $this->faker->sentence(),
+            'records_found' => $this->faker->optional(0.7)->numberBetween(0, 500),
+        ];
+    }
+
+    /**
+     * State for a draft data subject request
+     */
+    public function draft(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => Status::NEW->value,
+            'verification_status' => VerificationStatus::PENDING->value,
+            'priority' => Priority::NORMAL->value,
+        ]);
+    }
+
+    /**
+     * State for a verified data subject request
+     */
+    public function verified(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'verification_status' => VerificationStatus::VERIFIED->value,
+            'subject_key' => $this->faker->uuid(),
+            'verification_method' => $this->faker->randomElement(VerificationMethod::cases())->value,
+            'verified_by' => User::factory(),
+            'verification_date' => $this->faker->dateTime(),
+        ]);
+    }
+
+    /**
+     * State for an in-progress data subject request
+     */
+    public function inProgress(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => Status::IN_PROGRESS->value,
+            'verification_status' => VerificationStatus::VERIFIED->value,
+            'subject_key' => $this->faker->uuid(),
+            'verification_method' => $this->faker->randomElement(VerificationMethod::cases())->value,
+            'verified_by' => User::factory(),
+            'verification_date' => $this->faker->dateTime(),
+        ]);
+    }
+
+    /**
+     * State for a completed data subject request
+     */
+    public function completed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => Status::COMPLETED->value,
+            'verification_status' => VerificationStatus::VERIFIED->value,
+            'subject_key' => $this->faker->uuid(),
+            'verification_method' => $this->faker->randomElement(VerificationMethod::cases())->value,
+            'verified_by' => User::factory(),
+            'verification_date' => $this->faker->dateTime(),
+            'response_date' => $this->faker->dateTime(),
+            'completed_date' => $this->faker->dateTime(),
+            'response_method' => $this->faker->randomElement(ResponseMethod::cases())->value,
+            'response_format' => $this->faker->randomElement(ResponseFormat::cases())->value,
+            'response_uri' => $this->faker->url(),
+            'is_overdue' => false,
+        ]);
+    }
+
+    /**
+     * State for a high-priority data subject request
+     */
+    public function highPriority(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'priority' => Priority::URGENT->value,
+        ]);
+    }
+
+    /**
+     * State for a low-priority data subject request
+     */
+    public function lowPriority(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'priority' => Priority::LOW->value,
+        ]);
+    }
+
+    /**
+     * State for an overdue data subject request
+     */
+    public function overdue(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_overdue' => true,
+            'due_date' => now()->subDays($this->faker->numberBetween(1, 30)),
+        ]);
+    }
+
+    /**
+     * State for an access request
+     */
+    public function accessRequest(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'request_type' => RequestType::ACCESS->value,
+        ]);
+    }
+
+    /**
+     * State for an erasure request
+     */
+    public function erasureRequest(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'request_type' => RequestType::ERASURE->value,
+        ]);
+    }
+
+    /**
+     * State for a rectification request
+     */
+    public function rectificationRequest(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'request_type' => RequestType::RECTIFICATION->value,
+        ]);
+    }
+}

--- a/database/migrations/2025_12_09_081807_create_data_subject_request_accesses_table.php
+++ b/database/migrations/2025_12_09_081807_create_data_subject_request_accesses_table.php
@@ -30,7 +30,6 @@ return new class extends Migration
             $table->date('submitted_date');
             $table->date('due_date');
             $table->date('extended_due_date');
-            // $table->integer('days_remaining');
             $table->date('response_date')->nullable();
             $table->date('completed_date')->nullable();
             $table->string('status');

--- a/database/migrations/2025_12_10_000001_make_extended_due_date_nullable_on_data_subject_request_accesses_table.php
+++ b/database/migrations/2025_12_10_000001_make_extended_due_date_nullable_on_data_subject_request_accesses_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('data_subject_request_accesses', function (Blueprint $table) {
+            $table->date('extended_due_date')->nullable()->change();
+            $table->string('response_method')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('data_subject_request_accesses', function (Blueprint $table) {
+            $table->date('extended_due_date')->nullable(false)->change();
+            $table->string('response_method')->nullable(false)->change();
+        });
+    }
+};

--- a/routes/api/user.php
+++ b/routes/api/user.php
@@ -42,6 +42,7 @@ use App\Http\Controllers\IncidentRootCauseAnalysisController;
 use App\Http\Controllers\CorrectivePreventiveActionController;
 use App\Http\Controllers\User\PdpProcessingRegisterController;
 use App\Http\Controllers\User\DatasetSubjectPopulationController;
+use App\Http\Controllers\User\DataSubjectRequestAccessController;
 use App\Http\Controllers\User\RecordOfProcessingActivityController;
 
 Route::middleware(['auth:supabase'])->group(function () {
@@ -334,6 +335,14 @@ Route::middleware(['auth:supabase'])->group(function () {
         Route::get('{recordOfProcessingActivity}', 'show');
         Route::post('{recordOfProcessingActivity}', 'update');
         Route::delete('{recordOfProcessingActivity}', 'destroy');
+    });
+
+    Route::prefix('data-subject-request-accesses')->controller(DataSubjectRequestAccessController::class)->group(function () {
+        Route::get('', 'index');
+        Route::post('', 'store');
+        Route::get('{dataSubjectRequestAccess}', 'show');
+        Route::post('{dataSubjectRequestAccess}', 'update');
+        Route::delete('{dataSubjectRequestAccess}', 'destroy');
     });
 
 });

--- a/tests/Feature/DataSubjectRequestAccessControllerTest.php
+++ b/tests/Feature/DataSubjectRequestAccessControllerTest.php
@@ -1,0 +1,455 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\DataSubjectRequestAccess;
+use App\Enums\DataSubjectRequestAccess\Status;
+use App\Enums\DataSubjectRequestAccess\Priority;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Enums\DataSubjectRequestAccess\RequestType;
+use App\Enums\DataSubjectRequestAccess\SubjectRealm;
+use App\Enums\DataSubjectRequestAccess\RequestSource;
+use App\Enums\DataSubjectRequestAccess\VerificationMethod;
+use App\Enums\DataSubjectRequestAccess\VerificationStatus;
+
+class DataSubjectRequestAccessControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    /**
+     * Test listing data subject requests with default pagination
+     */
+    public function test_index_returns_paginated_data_subject_requests(): void
+    {
+        DataSubjectRequestAccess::factory(20)->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/data-subject-request-accesses');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('error', false);
+        $response->assertJsonPath('message', 'Data Subject Requests retrieved successfully');
+    }
+
+    /**
+     * Test listing data subject requests with status filter
+     */
+    public function test_index_filters_by_status(): void
+    {
+        DataSubjectRequestAccess::factory(5)->create(['status' => Status::NEW->value]);
+        DataSubjectRequestAccess::factory(3)->create(['status' => Status::COMPLETED->value]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/data-subject-request-accesses?status=completed');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(3, 'data.data');
+    }
+
+    /**
+     * Test listing data subject requests with request_type filter
+     */
+    public function test_index_filters_by_request_type(): void
+    {
+        DataSubjectRequestAccess::factory(4)->create(['request_type' => RequestType::ACCESS->value]);
+        DataSubjectRequestAccess::factory(2)->create(['request_type' => RequestType::ERASURE->value]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/data-subject-request-accesses?request_type=erasure');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data.data');
+    }
+
+    /**
+     * Test listing data subject requests with verification_status filter
+     */
+    public function test_index_filters_by_verification_status(): void
+    {
+        DataSubjectRequestAccess::factory(3)->create(['verification_status' => VerificationStatus::PENDING->value]);
+        DataSubjectRequestAccess::factory(2)->create(['verification_status' => VerificationStatus::VERIFIED->value]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/data-subject-request-accesses?verification_status=verified');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data.data');
+    }
+
+    /**
+     * Test listing data subject requests with priority filter
+     */
+    public function test_index_filters_by_priority(): void
+    {
+        DataSubjectRequestAccess::factory(3)->create(['priority' => Priority::LOW->value]);
+        DataSubjectRequestAccess::factory(2)->create(['priority' => Priority::URGENT->value]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/data-subject-request-accesses?priority=urgent');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data.data');
+    }
+
+    /**
+     * Test listing data subject requests with jurisdiction filter
+     */
+    public function test_index_filters_by_jurisdiction(): void
+    {
+        DataSubjectRequestAccess::factory(5)->create(['jurisdiction' => 'eu']);
+        DataSubjectRequestAccess::factory(2)->create(['jurisdiction' => 'ksa']);
+
+        $response = $this->actingAs($this->user)->getJson('/api/data-subject-request-accesses?jurisdiction=ksa');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data.data');
+    }
+
+    /**
+     * Test listing data subject requests with subject_realm filter
+     */
+    public function test_index_filters_by_subject_realm(): void
+    {
+        DataSubjectRequestAccess::factory(4)->create(['subject_realm' => SubjectRealm::CUSTOMER->value]);
+        DataSubjectRequestAccess::factory(2)->create(['subject_realm' => SubjectRealm::EMPLOYEE->value]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/data-subject-request-accesses?subject_realm=employee');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(2, 'data.data');
+    }
+
+    /**
+     * Test listing data subject requests with pagination
+     */
+    public function test_index_paginates_correctly(): void
+    {
+        DataSubjectRequestAccess::factory(25)->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/data-subject-request-accesses?per_page=10');
+
+        $response->assertStatus(200);
+        $response->assertJsonCount(10, 'data.data');
+    }
+
+    /**
+     * Test creating a data subject request access with all fields
+     */
+    public function test_store_creates_data_subject_request_access_with_all_fields(): void
+    {
+        $data = [
+            'request_type' => RequestType::ACCESS->value,
+            'subject_identifier' => 'user@example.com',
+            'subject_name' => 'John Doe',
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+            'verification_status' => VerificationStatus::VERIFIED->value,
+            'subject_key' => 'subj_123',
+            'verification_method' => VerificationMethod::EMAIL_LINK->value,
+            'verified_by' => $this->user->id,
+            'request_details' => 'Please provide all my personal data',
+            'requested_data_categories' => ['email', 'phone'],
+            'request_source' => RequestSource::EMAIL->value,
+            'submitted_date' => now()->toDateString(),
+            'due_date' => now()->addDays(30)->toDateString(),
+            'status' => Status::NEW->value,
+            'priority' => Priority::NORMAL->value,
+            'is_overdue' => false,
+            'assigned_to' => $this->user->id,
+            'assigned_date' => now()->toDateString(),
+            'jurisdiction' => 'EU',
+            'systems_checked' => 'CRM',
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/data-subject-request-accesses', $data);
+
+        $response->assertStatus(201);
+        $response->assertJsonPath('error', false);
+        $response->assertJsonPath('message', 'Data Subject Request Access created successfully');
+
+        $dsr = DataSubjectRequestAccess::where('subject_identifier', 'user@example.com')->first();
+        $this->assertNotNull($dsr);
+        $this->assertEquals(RequestType::ACCESS->value, $dsr->request_type);
+        $this->assertEquals('John Doe', $dsr->subject_name);
+    }
+
+    /**
+     * Test creating a data subject request auto-generates request_code
+     */
+    public function test_store_auto_generates_request_code(): void
+    {
+        $data = [
+            'request_type' => RequestType::ACCESS->value,
+            'subject_identifier' => 'test@example.com',
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+            'verification_status' => VerificationStatus::PENDING->value,
+            'request_details' => 'Test request',
+            'request_source' => RequestSource::EMAIL->value,
+            'submitted_date' => now()->toDateString(),
+            'due_date' => now()->addDays(30)->toDateString(),
+            'status' => Status::NEW->value,
+            'priority' => Priority::NORMAL->value,
+            'is_overdue' => false,
+            'assigned_to' => $this->user->id,
+            'assigned_date' => now()->toDateString(),
+            'jurisdiction' => 'EU',
+            'systems_checked' => 'CRM',
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/data-subject-request-accesses', $data);
+
+        $response->assertStatus(201);
+
+        $dsr = DataSubjectRequestAccess::where('subject_identifier', 'test@example.com')->first();
+        $this->assertNotNull($dsr->request_code);
+        $this->assertStringStartsWith('DSAR-'.date('Y'), $dsr->request_code);
+    }
+
+    /**
+     * Test creating a data subject request sets verification_date when verified
+     */
+    public function test_store_sets_verification_date_when_verified(): void
+    {
+        $data = [
+            'request_type' => RequestType::ACCESS->value,
+            'subject_identifier' => 'verified@example.com',
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+            'verification_status' => VerificationStatus::VERIFIED->value,
+            'subject_key' => 'subj_key',
+            'verification_method' => VerificationMethod::EMAIL_LINK->value,
+            'verified_by' => $this->user->id,
+            'request_details' => 'Test request',
+            'request_source' => RequestSource::EMAIL->value,
+            'submitted_date' => now()->toDateString(),
+            'due_date' => now()->addDays(30)->toDateString(),
+            'status' => Status::NEW->value,
+            'priority' => Priority::NORMAL->value,
+            'is_overdue' => false,
+            'assigned_to' => $this->user->id,
+            'assigned_date' => now()->toDateString(),
+            'jurisdiction' => 'EU',
+            'systems_checked' => 'CRM',
+
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/data-subject-request-accesses', $data);
+        $response->assertStatus(201);
+
+        $response = $response->json();
+        $this->assertNotNull($response['data']['verification_date']);
+    }
+
+    /**
+     * Test creating a data subject request with validation errors
+     */
+    public function test_store_validates_required_fields(): void
+    {
+        $data = [
+            'subject_identifier' => 'test@example.com',
+            // Missing required fields
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/data-subject-request-accesses', $data);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'request_type',
+            'subject_realm',
+            'verification_status',
+            'request_details',
+            'request_source',
+            'submitted_date',
+            'due_date',
+            'status',
+            'priority',
+            'is_overdue',
+            'assigned_to',
+            'assigned_date',
+        ]);
+    }
+
+    /**
+     * Test creating a data subject request with invalid enum values
+     */
+    public function test_store_validates_enum_values(): void
+    {
+        $data = [
+            'request_type' => 'invalid_type',
+            'subject_identifier' => 'test@example.com',
+            'subject_realm' => 'invalid_realm',
+            'verification_status' => 'invalid_status',
+            'request_details' => 'Test',
+            'request_source' => 'invalid_source',
+            'submitted_date' => now()->toDateString(),
+            'due_date' => now()->addDays(30)->toDateString(),
+            'status' => 'invalid_status',
+            'priority' => 'invalid_priority',
+            'is_overdue' => false,
+            'assigned_to' => $this->user->id,
+            'assigned_date' => now()->toDateString(),
+            'jurisdiction' => 'EU',
+            'systems_checked' => ['CRM'],
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/data-subject-request-accesses', $data);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors([
+            'request_type',
+            'subject_realm',
+            'verification_status',
+            'request_source',
+            'status',
+            'priority',
+        ]);
+    }
+
+    /**
+     * Test showing a data subject request
+     */
+    public function test_show_returns_data_subject_request(): void
+    {
+        $dsr = DataSubjectRequestAccess::factory()->create();
+
+        $response = $this->actingAs($this->user)->getJson("/api/data-subject-request-accesses/{$dsr->id}");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('error', false);
+        $response->assertJsonPath('data.id', $dsr->id);
+        $response->assertJsonPath('data.request_code', $dsr->request_code);
+    }
+
+    /**
+     * Test showing a non-existent data subject request returns 404
+     */
+    public function test_show_returns_404_for_non_existent_request(): void
+    {
+        $response = $this->actingAs($this->user)->getJson('/api/data-subject-request-accesses/99999');
+
+        $response->assertStatus(404);
+    }
+
+    /**
+     * Test updating a data subject request
+     */
+    public function test_update_modifies_data_subject_request(): void
+    {
+        $dsr = DataSubjectRequestAccess::factory()->create([
+            'status' => Status::NEW->value,
+            'priority' => Priority::LOW->value,
+        ]);
+
+        $data = [
+            'status' => Status::IN_PROGRESS->value,
+            'priority' => Priority::HIGH->value,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson("/api/data-subject-request-accesses/{$dsr->id}", $data);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('error', false);
+        $response->assertJsonPath('message', 'Data Subject Request Access updated successfully');
+
+        $updated = $dsr->fresh();
+        $this->assertEquals(Status::IN_PROGRESS->value, $updated->status);
+        $this->assertEquals(Priority::HIGH->value, $updated->priority);
+    }
+
+    /**
+     * Test updating a data subject request sets verification_date when changing to verified
+     */
+    public function test_update_sets_verification_date_when_changing_to_verified(): void
+    {
+        $dsr = DataSubjectRequestAccess::factory()->create([
+            'verification_status' => VerificationStatus::PENDING->value,
+            'verification_date' => null,
+        ]);
+
+        $data = [
+            'verification_status' => VerificationStatus::VERIFIED->value,
+            'subject_key' => 'subj_key_updated',
+            'verification_method' => VerificationMethod::EMAIL_LINK->value,
+            'verified_by' => $this->user->id,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson("/api/data-subject-request-accesses/{$dsr->id}", $data);
+
+        $response->assertStatus(200);
+
+        $updated = $dsr->fresh();
+        $this->assertNotNull($updated->verification_date);
+        $this->assertEquals(VerificationStatus::VERIFIED->value, $updated->verification_status);
+    }
+
+    /**
+     * Test updating a data subject request with partial data
+     */
+    public function test_update_with_partial_data(): void
+    {
+        $dsr = DataSubjectRequestAccess::factory()->create([
+            'status' => Status::NEW->value,
+            'priority' => Priority::LOW->value,
+            'request_type' => RequestType::ACCESS->value,
+        ]);
+
+        $data = ['status' => Status::IN_PROGRESS->value];
+
+        $response = $this->actingAs($this->user)->postJson("/api/data-subject-request-accesses/{$dsr->id}", $data);
+
+        $response->assertStatus(200);
+
+        $updated = $dsr->fresh();
+        $this->assertEquals(Status::IN_PROGRESS->value, $updated->status);
+        $this->assertEquals(Priority::LOW->value, $updated->priority);
+        $this->assertEquals(RequestType::ACCESS->value, $updated->request_type);
+    }
+
+    /**
+     * Test updating a data subject request with validation errors
+     */
+    public function test_update_validates_enum_values(): void
+    {
+        $dsr = DataSubjectRequestAccess::factory()->create();
+
+        $data = [
+            'status' => 'invalid_status',
+            'priority' => 'invalid_priority',
+        ];
+
+        $response = $this->actingAs($this->user)->postJson("/api/data-subject-request-accesses/{$dsr->id}", $data);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['status', 'priority']);
+    }
+
+    /**
+     * Test deleting a data subject request
+     */
+    public function test_destroy_deletes_data_subject_request(): void
+    {
+        $dsr = DataSubjectRequestAccess::factory()->create();
+        $id = $dsr->id;
+
+        $response = $this->actingAs($this->user)->deleteJson("/api/data-subject-request-accesses/{$dsr->id}");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('error', false);
+        $response->assertJsonPath('message', 'Data Subject Request Access deleted successfully');
+
+        $this->assertDatabaseMissing('data_subject_request_accesses', ['id' => $id]);
+    }
+
+    /**
+     * Test deleting a non-existent data subject request returns 404
+     */
+    public function test_destroy_returns_404_for_non_existent_request(): void
+    {
+        $response = $this->actingAs($this->user)->deleteJson('/api/data-subject-request-accesses/99999');
+
+        $response->assertStatus(404);
+    }
+}

--- a/tests/Unit/DataSubjectRequestAccessRepositoryTest.php
+++ b/tests/Unit/DataSubjectRequestAccessRepositoryTest.php
@@ -1,0 +1,393 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\DataSubjectRequestAccess;
+use App\Enums\DataSubjectRequestAccess\Status;
+use App\Enums\DataSubjectRequestAccess\Priority;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Enums\DataSubjectRequestAccess\RequestType;
+use App\Enums\DataSubjectRequestAccess\SubjectRealm;
+use App\Enums\DataSubjectRequestAccess\RequestSource;
+use App\Repositories\DataSubjectRequestAccessRepository;
+use App\Enums\DataSubjectRequestAccess\VerificationStatus;
+
+class DataSubjectRequestAccessRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private DataSubjectRequestAccessRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = app(DataSubjectRequestAccessRepository::class);
+    }
+
+    /**
+     * Test getting filtered data subject request accesses with default pagination
+     */
+    public function test_get_filtered_with_default_pagination(): void
+    {
+        DataSubjectRequestAccess::factory(20)->create();
+
+        $result = $this->repository->getFilteredDataSubjectRequestAccesses();
+
+        $this->assertCount(15, $result->items());
+        $this->assertEquals(20, $result->total());
+        $this->assertEquals(15, $result->perPage());
+    }
+
+    /**
+     * Test getting filtered data subject request accesses with custom per_page
+     */
+    public function test_get_filtered_with_custom_per_page(): void
+    {
+        DataSubjectRequestAccess::factory(30)->create();
+
+        $result = $this->repository->getFilteredDataSubjectRequestAccesses(['per_page' => 10]);
+
+        $this->assertCount(10, $result->items());
+        $this->assertEquals(30, $result->total());
+        $this->assertEquals(10, $result->perPage());
+    }
+
+    /**
+     * Test filtering by status
+     */
+    public function test_get_filtered_by_status(): void
+    {
+        DataSubjectRequestAccess::factory(5)->create(['status' => Status::NEW->value]);
+        DataSubjectRequestAccess::factory(3)->create(['status' => Status::COMPLETED->value]);
+
+        $result = $this->repository->getFilteredDataSubjectRequestAccesses(['status' => Status::COMPLETED->value]);
+
+        $this->assertCount(3, $result->items());
+        $this->assertTrue($result->items()[0]->status === Status::COMPLETED->value);
+    }
+
+    /**
+     * Test filtering by request_type
+     */
+    public function test_get_filtered_by_request_type(): void
+    {
+        DataSubjectRequestAccess::factory(4)->create(['request_type' => RequestType::ACCESS->value]);
+        DataSubjectRequestAccess::factory(2)->create(['request_type' => RequestType::ERASURE->value]);
+
+        $result = $this->repository->getFilteredDataSubjectRequestAccesses(['request_type' => RequestType::ERASURE->value]);
+
+        $this->assertCount(2, $result->items());
+        $this->assertTrue($result->items()[0]->request_type === RequestType::ERASURE->value);
+    }
+
+    /**
+     * Test filtering by verification_status
+     */
+    public function test_get_filtered_by_verification_status(): void
+    {
+        DataSubjectRequestAccess::factory(3)->create(['verification_status' => VerificationStatus::PENDING->value]);
+        DataSubjectRequestAccess::factory(2)->create(['verification_status' => VerificationStatus::VERIFIED->value]);
+
+        $result = $this->repository->getFilteredDataSubjectRequestAccesses(['verification_status' => VerificationStatus::VERIFIED->value]);
+
+        $this->assertCount(2, $result->items());
+        $this->assertTrue($result->items()[0]->verification_status === VerificationStatus::VERIFIED->value);
+    }
+
+    /**
+     * Test filtering by jurisdiction
+     */
+    public function test_get_filtered_by_jurisdiction(): void
+    {
+        DataSubjectRequestAccess::factory(5)->create(['jurisdiction' => 'EU']);
+        DataSubjectRequestAccess::factory(2)->create(['jurisdiction' => 'UAE']);
+
+        $result = $this->repository->getFilteredDataSubjectRequestAccesses(['jurisdiction' => 'UAE']);
+
+        $this->assertCount(2, $result->items());
+        $this->assertTrue($result->items()[0]->jurisdiction === 'UAE');
+    }
+
+    /**
+     * Test filtering by subject_realm
+     */
+    public function test_get_filtered_by_subject_realm(): void
+    {
+        DataSubjectRequestAccess::factory(4)->create(['subject_realm' => SubjectRealm::CUSTOMER->value]);
+        DataSubjectRequestAccess::factory(2)->create(['subject_realm' => SubjectRealm::EMPLOYEE->value]);
+
+        $result = $this->repository->getFilteredDataSubjectRequestAccesses(['subject_realm' => SubjectRealm::EMPLOYEE->value]);
+
+        $this->assertCount(2, $result->items());
+        $this->assertTrue($result->items()[0]->subject_realm === SubjectRealm::EMPLOYEE->value);
+    }
+
+    /**
+     * Test filtering by priority
+     */
+    public function test_get_filtered_by_priority(): void
+    {
+        DataSubjectRequestAccess::factory(3)->create(['priority' => Priority::LOW->value]);
+        DataSubjectRequestAccess::factory(2)->create(['priority' => Priority::HIGH->value]);
+
+        $result = $this->repository->getFilteredDataSubjectRequestAccesses(['priority' => Priority::HIGH->value]);
+
+        $this->assertCount(2, $result->items());
+        $this->assertTrue($result->items()[0]->priority === Priority::HIGH->value);
+    }
+
+    /**
+     * Test filtering with multiple criteria
+     */
+    public function test_get_filtered_with_multiple_filters(): void
+    {
+        DataSubjectRequestAccess::factory(5)->create([
+            'status' => Status::COMPLETED->value,
+            'request_type' => RequestType::ACCESS->value,
+            'priority' => Priority::HIGH->value,
+        ]);
+        DataSubjectRequestAccess::factory(3)->create([
+            'status' => Status::NEW->value,
+            'request_type' => RequestType::ERASURE->value,
+            'priority' => Priority::LOW->value,
+        ]);
+
+        $result = $this->repository->getFilteredDataSubjectRequestAccesses([
+            'status' => Status::COMPLETED->value,
+            'request_type' => RequestType::ACCESS->value,
+            'priority' => Priority::HIGH->value,
+        ]);
+
+        $this->assertCount(5, $result->items());
+    }
+
+    /**
+     * Test empty filters return all records
+     */
+    public function test_get_filtered_with_empty_filters(): void
+    {
+        DataSubjectRequestAccess::factory(5)->create();
+
+        $result = $this->repository->getFilteredDataSubjectRequestAccesses([]);
+
+        $this->assertCount(5, $result->items());
+    }
+
+    /**
+     * Test filtering with non-matching criteria returns empty
+     */
+    public function test_get_filtered_with_non_matching_criteria(): void
+    {
+        DataSubjectRequestAccess::factory(5)->create(['status' => Status::NEW->value]);
+
+        $result = $this->repository->getFilteredDataSubjectRequestAccesses(['status' => Status::COMPLETED->value]);
+
+        $this->assertCount(0, $result->items());
+        $this->assertEquals(0, $result->total());
+    }
+
+    /**
+     * Test pagination with total count
+     */
+    public function test_get_filtered_pagination_with_total(): void
+    {
+        DataSubjectRequestAccess::factory(25)->create();
+
+        $result = $this->repository->getFilteredDataSubjectRequestAccesses(['per_page' => 10]);
+
+        $this->assertEquals(25, $result->total());
+        $this->assertEquals(3, $result->lastPage());
+        $this->assertTrue($result->hasPages());
+    }
+
+    /**
+     * Test creating a data subject request access
+     */
+    public function test_create_data_subject_request_access(): void
+    {
+        $user = User::factory()->create();
+        $data = [
+            'request_code' => 'DSR-001',
+            'request_type' => RequestType::ACCESS->value,
+            'subject_identifier' => 'user@example.com',
+            'subject_key' => 'subj_123',
+            'subject_name' => 'John Doe',
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+            'verification_status' => VerificationStatus::VERIFIED->value,
+            'verification_method' => 'email',
+            'verified_by' => 1,
+            'request_details' => 'Please provide all my personal data',
+            'requested_data_categories' => ['email', 'phone'],
+            'request_source' => RequestSource::EMAIL->value,
+            'submitted_date' => now(),
+            'due_date' => now()->addDays(30),
+            'status' => Status::NEW->value,
+            'priority' => Priority::NORMAL->value,
+            'is_overdue' => false,
+            'assigned_to' => $user->id,
+            'assigned_date' => now(),
+            'jurisdiction' => 'EU',
+            'systems_checked' => 'Dwerty',
+            'records_found' => 15,
+        ];
+
+        $dsr = $this->repository->createDataSubjectRequestAccess($data);
+
+        $this->assertInstanceOf(DataSubjectRequestAccess::class, $dsr);
+        $this->assertEquals('DSR-001', $dsr->request_code);
+        $this->assertEquals(RequestType::ACCESS->value, $dsr->request_type);
+        $this->assertEquals('John Doe', $dsr->subject_name);
+        $this->assertDatabaseHas('data_subject_request_accesses', ['request_code' => 'DSR-001']);
+    }
+
+    /**
+     * Test creating data subject request access with minimal data
+     */
+    public function test_create_data_subject_request_access_with_minimal_data(): void
+    {
+        $user = User::factory()->create();
+
+        $data = [
+            'request_code' => 'DSR-minimal',
+            'request_type' => RequestType::ACCESS->value,
+            'subject_identifier' => 'minimal@example.com',
+            'subject_realm' => SubjectRealm::CUSTOMER->value,
+            'verification_status' => VerificationStatus::PENDING->value,
+            'request_details' => 'Access request',
+            'request_source' => RequestSource::WEB_FORM->value,
+            'submitted_date' => now(),
+            'due_date' => now()->addDays(30),
+            'status' => Status::NEW->value,
+            'priority' => Priority::NORMAL->value,
+            'is_overdue' => false,
+            'assigned_to' => $user->id,
+            'assigned_date' => now(),
+            'jurisdiction' => 'EU',
+            'systems_checked' => 'Dwerty',
+        ];
+
+        $dsr = $this->repository->createDataSubjectRequestAccess($data);
+
+        $this->assertNotNull($dsr->id);
+        $this->assertEquals('DSR-minimal', $dsr->request_code);
+    }
+
+    /**
+     * Test updating a data subject request access
+     */
+    public function test_update_data_subject_request_access(): void
+    {
+        $dsr = DataSubjectRequestAccess::factory()->create([
+            'status' => Status::NEW->value,
+            'priority' => Priority::LOW->value,
+        ]);
+
+        $data = [
+            'status' => Status::IN_PROGRESS->value,
+            'priority' => Priority::HIGH->value,
+        ];
+
+        $updated = $this->repository->updateDataSubjectRequestAccess($dsr, $data);
+
+        $this->assertEquals(Status::IN_PROGRESS->value, $updated->status);
+        $this->assertEquals(Priority::HIGH->value, $updated->priority);
+        $this->assertDatabaseHas('data_subject_request_accesses', [
+            'id' => $dsr->id,
+            'status' => Status::IN_PROGRESS->value,
+        ]);
+    }
+
+    /**
+     * Test updating data subject request access with partial data
+     */
+    public function test_update_data_subject_request_access_with_partial_data(): void
+    {
+        $dsr = DataSubjectRequestAccess::factory()->create([
+            'status' => Status::NEW->value,
+            'priority' => Priority::LOW->value,
+            'request_type' => RequestType::ACCESS->value,
+        ]);
+
+        $data = ['status' => Status::IN_PROGRESS->value];
+
+        $updated = $this->repository->updateDataSubjectRequestAccess($dsr, $data);
+
+        $this->assertEquals(Status::IN_PROGRESS->value, $updated->status);
+        $this->assertEquals(Priority::LOW->value, $updated->priority);
+        $this->assertEquals(RequestType::ACCESS->value, $updated->request_type);
+    }
+
+    /**
+     * Test updating data subject request access returns fresh instance
+     */
+    public function test_update_data_subject_request_access_returns_fresh_instance(): void
+    {
+        $dsr = DataSubjectRequestAccess::factory()->create(['status' => Status::NEW->value]);
+
+        $data = ['status' => Status::IN_PROGRESS->value];
+
+        $updated = $this->repository->updateDataSubjectRequestAccess($dsr, $data);
+
+        $this->assertEquals(Status::IN_PROGRESS->value, $updated->status);
+    }
+
+    /**
+     * Test deleting a data subject request access
+     */
+    public function test_delete_data_subject_request_access(): void
+    {
+        $dsr = DataSubjectRequestAccess::factory()->create();
+        $id = $dsr->id;
+
+        $result = $this->repository->deleteDataSubjectRequestAccess($dsr);
+
+        $this->assertTrue($result);
+        $this->assertDatabaseMissing('data_subject_request_accesses', ['id' => $id]);
+    }
+
+    /**
+     * Test deleting non-existent data subject request access
+     */
+    public function test_delete_non_existent_data_subject_request_access(): void
+    {
+        $dsr = DataSubjectRequestAccess::factory()->make();
+
+        $result = $this->repository->deleteDataSubjectRequestAccess($dsr);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test filtering by status with different statuses
+     */
+    public function test_filtering_by_all_status_values(): void
+    {
+        foreach (Status::cases() as $status) {
+            DataSubjectRequestAccess::factory()->create(['status' => $status->value]);
+        }
+
+        foreach (Status::cases() as $status) {
+            $result = $this->repository->getFilteredDataSubjectRequestAccesses(['status' => $status->value]);
+            $this->assertCount(1, $result->items());
+            $this->assertEquals($status->value, $result->items()[0]->status);
+        }
+    }
+
+    /**
+     * Test filtering by priority with different priorities
+     */
+    public function test_filtering_by_all_priority_values(): void
+    {
+        foreach (Priority::cases() as $priority) {
+            DataSubjectRequestAccess::factory()->create(['priority' => $priority->value]);
+        }
+
+        foreach (Priority::cases() as $priority) {
+            $result = $this->repository->getFilteredDataSubjectRequestAccesses(['priority' => $priority->value]);
+            $this->assertCount(1, $result->items());
+            $this->assertEquals($priority->value, $result->items()[0]->priority);
+        }
+    }
+}


### PR DESCRIPTION
- Created DataSubjectRequestAccessRepository for handling data subject request access operations.
- Added DataSubjectRequestAccessFactory for generating test data.
- Created migration for data_subject_request_accesses table with necessary fields.
- Added nullable extended_due_date and response_method in a new migration.
- Defined API routes for data subject request accesses.
- Developed DataSubjectRequestAccessController with CRUD operations.
- Implemented feature tests for DataSubjectRequestAccessController.
- Created unit tests for DataSubjectRequestAccessRepository to validate filtering and CRUD operations.