### PR TITLE
feat: add AI Committees management functionality

### DIFF
--- a/app/Enums/AiCommittee/Cadence.php
+++ b/app/Enums/AiCommittee/Cadence.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums\AiCommittee;
+
+enum Cadence: string
+{
+    case WEEKLY = 'weekly';
+    case BIWEEKLY = 'biweekly';
+    case MONTHLY = 'monthly';
+    case QUARTERLY = 'quarterly';
+    case AD_HOC = 'ad_hoc';
+}

--- a/app/Enums/AiCommittee/Type.php
+++ b/app/Enums/AiCommittee/Type.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums\AiCommittee;
+
+enum Type: string
+{
+    case GOVERNANCE = 'governance';
+    case ETHICS = 'ethics';
+    case RISK = 'risk';
+    case SECURITY = 'security';
+    case PRIVACY = 'privacy';
+    case PRODUCT_OPS = 'product_ops';
+    case OTHER = 'other';
+}

--- a/app/Http/Controllers/User/AiCommitteeController.php
+++ b/app/Http/Controllers/User/AiCommitteeController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Http\Controllers\User;
+
+use App\Models\AiCommittee;
+use Illuminate\Http\JsonResponse;
+use App\Http\Controllers\Controller;
+use App\Http\Resources\AiCommitteeResource;
+use App\Repositories\AiCommitteeRepository;
+use App\Http\Requests\AiCommittee\ListAiCommitteeRequest;
+use App\Http\Requests\AiCommittee\StoreAiCommitteeRequest;
+use App\Http\Requests\AiCommittee\UpdateAiCommitteeRequest;
+
+class AiCommitteeController extends Controller
+{
+    public function __construct(private AiCommitteeRepository $repository) {}
+
+    /**
+     * Get all AI committees with filtering and pagination.
+     */
+    public function index(ListAiCommitteeRequest $request): JsonResponse
+    {
+        $validated = $request->validated();
+        $committees = $this->repository->getFilteredCommittees($validated);
+
+        return response()->json([
+            'data' => $committees,
+            'message' => 'AI Committees retrieved successfully.',
+            'error' => false,
+        ]);
+    }
+
+    /**
+     * Create a new AI committee.
+     */
+    public function store(StoreAiCommitteeRequest $request): JsonResponse
+    {
+        $validated = $request->validated();
+        $committee = $this->repository->createCommittee($validated);
+
+        return response()->json([
+            'data' => new AiCommitteeResource($committee),
+            'message' => 'AI Committee created successfully.',
+            'error' => false,
+        ], 201);
+    }
+
+    /**
+     * Get a specific AI committee.
+     */
+    public function show(AiCommittee $aiCommittee): JsonResponse
+    {
+        return response()->json([
+            'data' => new AiCommitteeResource($aiCommittee),
+            'message' => 'AI Committee retrieved successfully.',
+            'error' => false,
+        ]);
+    }
+
+    /**
+     * Update an existing AI committee.
+     */
+    public function update(UpdateAiCommitteeRequest $request, AiCommittee $aiCommittee): JsonResponse
+    {
+        $validated = $request->validated();
+        $committee = $this->repository->updateCommittee($aiCommittee, $validated);
+
+        return response()->json([
+            'data' => new AiCommitteeResource($committee),
+            'message' => 'AI Committee updated successfully.',
+            'error' => false,
+        ]);
+    }
+
+    /**
+     * Delete an AI committee.
+     */
+    public function destroy(AiCommittee $aiCommittee): JsonResponse
+    {
+        $this->repository->deleteCommittee($aiCommittee);
+
+        return response()->json([
+            'data' => null,
+            'message' => 'AI Committee deleted successfully.',
+            'error' => false,
+        ]);
+    }
+}

--- a/app/Http/Requests/AiCommittee/ListAiCommitteeRequest.php
+++ b/app/Http/Requests/AiCommittee/ListAiCommitteeRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\AiCommittee;
+
+use App\Enums\AiCommittee\Type;
+use Illuminate\Validation\Rule;
+use App\Enums\AiCommittee\Cadence;
+use Illuminate\Foundation\Http\FormRequest;
+
+class ListAiCommitteeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'type' => ['nullable', Rule::enum(Type::class)],
+            'cadence' => ['nullable', Rule::enum(Cadence::class)],
+            'active' => ['nullable', 'boolean'],
+            'name' => ['nullable', 'string', 'max:255'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ];
+    }
+}

--- a/app/Http/Requests/AiCommittee/StoreAiCommitteeRequest.php
+++ b/app/Http/Requests/AiCommittee/StoreAiCommitteeRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\AiCommittee;
+
+use App\Enums\AiCommittee\Type;
+use Illuminate\Validation\Rule;
+use App\Enums\AiCommittee\Cadence;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreAiCommitteeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'min:2', 'max:255'],
+            'type' => ['required', Rule::enum(Type::class)],
+            'charter' => ['required', 'string'],
+            'cadence' => ['required', Rule::enum(Cadence::class)],
+            'owner_team' => ['required', 'string', 'max:255'],
+            'active' => ['required', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/AiCommittee/UpdateAiCommitteeRequest.php
+++ b/app/Http/Requests/AiCommittee/UpdateAiCommitteeRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests\AiCommittee;
+
+use App\Enums\AiCommittee\Type;
+use Illuminate\Validation\Rule;
+use App\Enums\AiCommittee\Cadence;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateAiCommitteeRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string', 'min:2', 'max:255'],
+            'type' => ['sometimes', 'required', Rule::enum(Type::class)],
+            'charter' => ['sometimes', 'required', 'string'],
+            'cadence' => ['sometimes', 'required', Rule::enum(Cadence::class)],
+            'owner_team' => ['sometimes', 'required', 'string', 'max:255'],
+            'active' => ['sometimes', 'required', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Resources/AiCommitteeResource.php
+++ b/app/Http/Resources/AiCommitteeResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\AiCommittee;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin AiCommittee
+ */
+class AiCommitteeResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'type' => $this->type,
+            'charter' => $this->charter,
+            'cadence' => $this->cadence,
+            'owner_team' => $this->owner_team,
+            'active' => $this->active,
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/AiCommittee.php
+++ b/app/Models/AiCommittee.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class AiCommittee extends Model
+{
+    /** @use HasFactory<\Database\Factories\AiCommitteeFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'type',
+        'charter',
+        'cadence',
+        'owner_team',
+        'active',
+    ];
+
+    protected $casts = [
+        'active' => 'boolean',
+    ];
+}

--- a/app/Repositories/AiCommitteeRepository.php
+++ b/app/Repositories/AiCommitteeRepository.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Repositories;
+
+use App\Models\AiCommittee;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+class AiCommitteeRepository
+{
+    /**
+     * Get paginated list of AI committees with specified filters.
+     *
+     * @return \Illuminate\Pagination\LengthAwarePaginator<int, AiCommittee>
+     */
+    public function getFilteredCommittees(array $filters = []): LengthAwarePaginator
+    {
+        $query = AiCommittee::query();
+
+        if (isset($filters['type']) && ! empty($filters['type'])) {
+            $query->where('type', $filters['type']);
+        }
+
+        if (isset($filters['cadence']) && ! empty($filters['cadence'])) {
+            $query->where('cadence', $filters['cadence']);
+        }
+
+        if (isset($filters['active'])) {
+            $query->where('active', (bool) $filters['active']);
+        }
+
+        if (isset($filters['name']) && ! empty($filters['name'])) {
+            $query->where('name', 'like', '%'.$filters['name'].'%');
+        }
+
+        $perPage = $filters['per_page'] ?? 15;
+
+        return $query->orderBy('created_at', 'desc')->paginate($perPage);
+    }
+
+    /**
+     * Create a new AI committee.
+     */
+    public function createCommittee(array $data): AiCommittee
+    {
+        return AiCommittee::create($data);
+    }
+
+    /**
+     * Update an existing AI committee.
+     */
+    public function updateCommittee(AiCommittee $committee, array $data): AiCommittee
+    {
+        $committee->update($data);
+
+        return $committee->fresh();
+    }
+
+    /**
+     * Delete an AI committee.
+     */
+    public function deleteCommittee(AiCommittee $committee): bool
+    {
+        return (bool) $committee->delete();
+    }
+}

--- a/database/factories/AiCommitteeFactory.php
+++ b/database/factories/AiCommitteeFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\AiCommittee\Type;
+use App\Enums\AiCommittee\Cadence;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\AiCommittee>
+ */
+class AiCommitteeFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->words(3, true),
+            'type' => $this->faker->randomElement(Type::cases())->value,
+            'charter' => $this->faker->paragraph(),
+            'cadence' => $this->faker->randomElement(Cadence::cases())->value,
+            'owner_team' => $this->faker->randomElement(['ai-governance', 'ethics', 'compliance', 'risk-management']),
+            'active' => $this->faker->boolean(80),
+        ];
+    }
+
+    /**
+     * Indicate that the committee is active.
+     */
+    public function active(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'active' => true,
+        ]);
+    }
+
+    /**
+     * Indicate that the committee is inactive.
+     */
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'active' => false,
+        ]);
+    }
+}

--- a/database/migrations/2025_12_19_071141_create_ai_committees_table.php
+++ b/database/migrations/2025_12_19_071141_create_ai_committees_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('ai_committees', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('type');
+            $table->text('charter');
+            $table->string('cadence');
+            $table->string('owner_team');
+            $table->boolean('active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('ai_committees');
+    }
+};

--- a/routes/api/user.php
+++ b/routes/api/user.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\User\FrameworkController;
 use App\Http\Controllers\AiModelArtifactController;
 use App\Http\Controllers\User\AiIncidentController;
 use App\Http\Controllers\User\DataSourceController;
+use App\Http\Controllers\User\AiCommitteeController;
 use App\Http\Controllers\User\AiModelCardController;
 use App\Http\Controllers\User\DataElementController;
 use App\Http\Controllers\User\StakeholderController;
@@ -395,6 +396,14 @@ Route::middleware(['auth:supabase'])->group(function () {
         Route::get('{regulatorySubmission}', 'show');
         Route::post('{regulatorySubmission}', 'update');
         Route::delete('{regulatorySubmission}', 'destroy');
+    });
+
+    Route::prefix('/ai-committees')->controller(AiCommitteeController::class)->group(function () {
+        Route::get('', 'index');
+        Route::post('', 'store');
+        Route::get('{aiCommittee}', 'show');
+        Route::post('{aiCommittee}', 'update');
+        Route::delete('{aiCommittee}', 'destroy');
     });
 
 });

--- a/tests/Feature/Controllers/User/AiCommitteeControllerTest.php
+++ b/tests/Feature/Controllers/User/AiCommitteeControllerTest.php
@@ -1,0 +1,791 @@
+<?php
+
+namespace Tests\Feature\Controllers\User;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\AiCommittee;
+use App\Models\Organization;
+use App\Enums\AiCommittee\Type;
+use App\Enums\AiCommittee\Cadence;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class AiCommitteeControllerTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    private User $user;
+
+    private Organization $organization;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->organization = Organization::factory()->create();
+        $this->user = User::factory()->create([
+            'organization_id' => $this->organization->id,
+        ]);
+    }
+
+    /**
+     * Test index returns all committees with default pagination
+     */
+    public function test_index_returns_all_committees(): void
+    {
+        AiCommittee::factory(5)->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/ai-committees');
+
+        $response->assertOk()
+            ->assertJsonStructure(['data', 'message', 'error'])
+            ->assertJsonPath('error', false)
+            ->assertJsonPath('message', 'AI Committees retrieved successfully.');
+    }
+
+    /**
+     * Test index returns paginated results with default limit of 15
+     */
+    public function test_index_returns_paginated_results(): void
+    {
+        AiCommittee::factory(20)->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/ai-committees');
+
+        $response->assertOk()
+            ->assertJsonPath('data.per_page', 15)
+            ->assertJsonCount(15, 'data.data');
+    }
+
+    /**
+     * Test index with custom per_page parameter
+     */
+    public function test_index_with_custom_per_page(): void
+    {
+        AiCommittee::factory(25)->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/ai-committees?per_page=10');
+
+        $response->assertOk()
+            ->assertJsonPath('data.per_page', 10)
+            ->assertJsonCount(10, 'data.data');
+    }
+
+    /**
+     * Test index validates per_page parameter - maximum value
+     */
+    public function test_index_validates_per_page_maximum(): void
+    {
+        $response = $this->actingAs($this->user)->getJson('/api/ai-committees?per_page=999');
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['per_page']);
+    }
+
+    /**
+     * Test index validates per_page parameter - minimum value
+     */
+    public function test_index_validates_per_page_minimum(): void
+    {
+        $response = $this->actingAs($this->user)->getJson('/api/ai-committees?per_page=0');
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['per_page']);
+    }
+
+    /**
+     * Test index filter by type
+     */
+    public function test_index_filter_by_type(): void
+    {
+        AiCommittee::factory(5)->create(['type' => Type::GOVERNANCE->value]);
+        AiCommittee::factory(3)->create(['type' => Type::ETHICS->value]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/ai-committees?type='.Type::GOVERNANCE->value);
+
+        $response->assertOk()
+            ->assertJsonPath('data.total', 5);
+
+        $this->assertTrue(
+            collect($response->json('data.data'))
+                ->every(fn ($item) => $item['type'] === Type::GOVERNANCE->value)
+        );
+    }
+
+    /**
+     * Test index filter by cadence
+     */
+    public function test_index_filter_by_cadence(): void
+    {
+        AiCommittee::factory(4)->create(['cadence' => Cadence::MONTHLY->value]);
+        AiCommittee::factory(6)->create(['cadence' => Cadence::QUARTERLY->value]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/ai-committees?cadence='.Cadence::MONTHLY->value);
+
+        $response->assertOk()
+            ->assertJsonPath('data.total', 4);
+
+        $this->assertTrue(
+            collect($response->json('data.data'))
+                ->every(fn ($item) => $item['cadence'] === Cadence::MONTHLY->value)
+        );
+    }
+
+    /**
+     * Test index filter by active status
+     */
+    public function test_index_filter_by_active_true(): void
+    {
+        AiCommittee::factory(8)->active()->create();
+        AiCommittee::factory(5)->inactive()->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/ai-committees?active=1');
+
+        $response->assertOk()
+            ->assertJsonPath('data.total', 8);
+
+        $this->assertTrue(
+            collect($response->json('data.data'))
+                ->every(fn ($item) => $item['active'] === true)
+        );
+    }
+
+    /**
+     * Test index filter by inactive status
+     */
+    public function test_index_filter_by_active_false(): void
+    {
+        AiCommittee::factory(7)->active()->create();
+        AiCommittee::factory(6)->inactive()->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/ai-committees?active=0');
+
+        $response->assertOk()
+            ->assertJsonPath('data.total', 6);
+
+        $this->assertTrue(
+            collect($response->json('data.data'))
+                ->every(fn ($item) => $item['active'] === false)
+        );
+    }
+
+    /**
+     * Test index filter by name with partial match
+     */
+    public function test_index_filter_by_name(): void
+    {
+        AiCommittee::factory()->create(['name' => 'Governance Committee']);
+        AiCommittee::factory()->create(['name' => 'Ethics Board']);
+        AiCommittee::factory()->create(['name' => 'Risk Management Committee']);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/ai-committees?name=Committee');
+
+        $response->assertOk()
+            ->assertJsonPath('data.total', 2);
+    }
+
+    /**
+     * Test index with multiple filters combined
+     */
+    public function test_index_with_multiple_filters(): void
+    {
+        AiCommittee::factory(10)->create([
+            'type' => Type::GOVERNANCE->value,
+            'cadence' => Cadence::MONTHLY->value,
+            'active' => true,
+        ]);
+
+        AiCommittee::factory(5)->create([
+            'type' => Type::GOVERNANCE->value,
+            'cadence' => Cadence::QUARTERLY->value,
+            'active' => true,
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->getJson('/api/ai-committees?type='.Type::GOVERNANCE->value.'&cadence='.Cadence::MONTHLY->value.'&active=1');
+
+        $response->assertOk()
+            ->assertJsonPath('data.total', 10);
+    }
+
+    /**
+     * Test index returns correct resource structure
+     */
+    public function test_index_returns_correct_resource_structure(): void
+    {
+        AiCommittee::factory(3)->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/ai-committees');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => [
+                    'data' => [
+                        '*' => ['id', 'name', 'type', 'charter', 'cadence', 'owner_team', 'active', 'created_at', 'updated_at'],
+                    ],
+                    'total',
+                    'per_page',
+                    'current_page',
+                ],
+                'message',
+                'error',
+            ]);
+    }
+
+    /**
+     * Test index returns empty list when no committees exist
+     */
+    public function test_index_returns_empty_list(): void
+    {
+        $response = $this->actingAs($this->user)->getJson('/api/ai-committees');
+
+        $response->assertOk()
+            ->assertJsonPath('data.total', 0)
+            ->assertJsonCount(0, 'data.data');
+    }
+
+    /**
+     * Test unauthenticated user cannot access index
+     */
+    public function test_unauthenticated_user_cannot_access_index(): void
+    {
+        $response = $this->getJson('/api/ai-committees');
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * Test store creates a new committee
+     */
+    public function test_store_creates_committee(): void
+    {
+        $data = [
+            'name' => 'AI Governance Committee',
+            'type' => Type::GOVERNANCE->value,
+            'charter' => 'Committee charter document',
+            'cadence' => Cadence::MONTHLY->value,
+            'owner_team' => 'Executive Team',
+            'active' => true,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-committees', $data);
+
+        $response->assertCreated()
+            ->assertJsonPath('error', false)
+            ->assertJsonPath('message', 'AI Committee created successfully.')
+            ->assertJsonPath('data.name', 'AI Governance Committee')
+            ->assertJsonPath('data.type', Type::GOVERNANCE->value)
+            ->assertJsonPath('data.cadence', Cadence::MONTHLY->value)
+            ->assertJsonPath('data.active', true);
+
+        $this->assertDatabaseHas('ai_committees', ['name' => 'AI Governance Committee']);
+    }
+
+    /**
+     * Test store returns 201 created status
+     */
+    public function test_store_returns_201_created(): void
+    {
+        $data = [
+            'name' => 'Ethics Committee',
+            'type' => Type::ETHICS->value,
+            'charter' => 'Ethics charter',
+            'cadence' => Cadence::QUARTERLY->value,
+            'owner_team' => 'Chief Ethics Officer',
+            'active' => true,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-committees', $data);
+
+        $this->assertEquals(201, $response->getStatusCode());
+    }
+
+    /**
+     * Test store validates required fields
+     */
+    public function test_store_validates_required_fields(): void
+    {
+        $response = $this->actingAs($this->user)->postJson('/api/ai-committees', []);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['name', 'type', 'charter', 'cadence', 'owner_team', 'active']);
+    }
+
+    /**
+     * Test store validates name field
+     */
+    public function test_store_validates_name_field(): void
+    {
+        $data = [
+            'name' => 'A', // Too short
+            'type' => Type::GOVERNANCE->value,
+            'charter' => 'Charter',
+            'cadence' => Cadence::MONTHLY->value,
+            'owner_team' => 'Team',
+            'active' => true,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-committees', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['name']);
+    }
+
+    /**
+     * Test store validates type enum
+     */
+    public function test_store_validates_type_enum(): void
+    {
+        $data = [
+            'name' => 'Test Committee',
+            'type' => 'invalid_type',
+            'charter' => 'Charter',
+            'cadence' => Cadence::MONTHLY->value,
+            'owner_team' => 'Team',
+            'active' => true,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-committees', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['type']);
+    }
+
+    /**
+     * Test store validates cadence enum
+     */
+    public function test_store_validates_cadence_enum(): void
+    {
+        $data = [
+            'name' => 'Test Committee',
+            'type' => Type::GOVERNANCE->value,
+            'charter' => 'Charter',
+            'cadence' => 'invalid_cadence',
+            'owner_team' => 'Team',
+            'active' => true,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-committees', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['cadence']);
+    }
+
+    /**
+     * Test store validates active field is boolean
+     */
+    public function test_store_validates_active_boolean(): void
+    {
+        $data = [
+            'name' => 'Test Committee',
+            'type' => Type::GOVERNANCE->value,
+            'charter' => 'Charter',
+            'cadence' => Cadence::MONTHLY->value,
+            'owner_team' => 'Team',
+            'active' => 'not_boolean',
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-committees', $data);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['active']);
+    }
+
+    /**
+     * Test store with all type enum values
+     */
+    public function test_store_with_all_type_values(): void
+    {
+        foreach (Type::cases() as $type) {
+            $data = [
+                'name' => 'Committee '.$type->value,
+                'type' => $type->value,
+                'charter' => 'Charter',
+                'cadence' => Cadence::MONTHLY->value,
+                'owner_team' => 'Team',
+                'active' => true,
+            ];
+
+            $response = $this->actingAs($this->user)->postJson('/api/ai-committees', $data);
+
+            $response->assertCreated()
+                ->assertJsonPath('data.type', $type->value);
+        }
+    }
+
+    /**
+     * Test store with all cadence enum values
+     */
+    public function test_store_with_all_cadence_values(): void
+    {
+        foreach (Cadence::cases() as $cadence) {
+            $data = [
+                'name' => 'Committee '.$cadence->value,
+                'type' => Type::GOVERNANCE->value,
+                'charter' => 'Charter',
+                'cadence' => $cadence->value,
+                'owner_team' => 'Team',
+                'active' => true,
+            ];
+
+            $response = $this->actingAs($this->user)->postJson('/api/ai-committees', $data);
+
+            $response->assertCreated()
+                ->assertJsonPath('data.cadence', $cadence->value);
+        }
+    }
+
+    /**
+     * Test store returns new committee with timestamps
+     */
+    public function test_store_returns_committee_with_timestamps(): void
+    {
+        $data = [
+            'name' => 'Test Committee',
+            'type' => Type::GOVERNANCE->value,
+            'charter' => 'Charter',
+            'cadence' => Cadence::MONTHLY->value,
+            'owner_team' => 'Team',
+            'active' => true,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson('/api/ai-committees', $data);
+
+        $response->assertCreated()
+            ->assertJsonStructure(['data' => ['created_at', 'updated_at']])
+            ->assertJsonPath('data.created_at', fn ($value) => ! empty($value))
+            ->assertJsonPath('data.updated_at', fn ($value) => ! empty($value));
+    }
+
+    /**
+     * Test unauthenticated user cannot store
+     */
+    public function test_unauthenticated_user_cannot_store(): void
+    {
+        $data = [
+            'name' => 'Test Committee',
+            'type' => Type::GOVERNANCE->value,
+            'charter' => 'Charter',
+            'cadence' => Cadence::MONTHLY->value,
+            'owner_team' => 'Team',
+            'active' => true,
+        ];
+
+        $response = $this->postJson('/api/ai-committees', $data);
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * Test show returns specific committee
+     */
+    public function test_show_returns_committee(): void
+    {
+        $committee = AiCommittee::factory()->create([
+            'name' => 'Test Committee',
+            'type' => Type::ETHICS->value,
+        ]);
+
+        $response = $this->actingAs($this->user)->getJson('/api/ai-committees/'.$committee->id);
+
+        $response->assertOk()
+            ->assertJsonPath('error', false)
+            ->assertJsonPath('message', 'AI Committee retrieved successfully.')
+            ->assertJsonPath('data.id', $committee->id)
+            ->assertJsonPath('data.name', 'Test Committee')
+            ->assertJsonPath('data.type', Type::ETHICS->value);
+    }
+
+    /**
+     * Test show returns correct resource structure
+     */
+    public function test_show_returns_correct_structure(): void
+    {
+        $committee = AiCommittee::factory()->create();
+
+        $response = $this->actingAs($this->user)->getJson('/api/ai-committees/'.$committee->id);
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'data' => ['id', 'name', 'type', 'charter', 'cadence', 'owner_team', 'active', 'created_at', 'updated_at'],
+                'message',
+                'error',
+            ]);
+    }
+
+    /**
+     * Test show returns 404 for non-existent committee
+     */
+    public function test_show_returns_404_for_nonexistent(): void
+    {
+        $response = $this->actingAs($this->user)->getJson('/api/ai-committees/99999');
+
+        $response->assertNotFound();
+    }
+
+    /**
+     * Test unauthenticated user cannot access show
+     */
+    public function test_unauthenticated_user_cannot_show(): void
+    {
+        $committee = AiCommittee::factory()->create();
+
+        $response = $this->getJson('/api/ai-committees/'.$committee->id);
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * Test update modifies committee
+     */
+    public function test_update_modifies_committee(): void
+    {
+        $committee = AiCommittee::factory()->create([
+            'name' => 'Original Name',
+            'type' => Type::GOVERNANCE->value,
+            'active' => true,
+        ]);
+
+        $updateData = [
+            'name' => 'Updated Name',
+            'type' => Type::ETHICS->value,
+            'active' => false,
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/ai-committees/'.$committee->id, $updateData);
+
+        $response->assertOk()
+            ->assertJsonPath('error', false)
+            ->assertJsonPath('message', 'AI Committee updated successfully.')
+            ->assertJsonPath('data.name', 'Updated Name')
+            ->assertJsonPath('data.type', Type::ETHICS->value)
+            ->assertJsonPath('data.active', false);
+
+        $this->assertDatabaseHas('ai_committees', [
+            'id' => $committee->id,
+            'name' => 'Updated Name',
+            'type' => Type::ETHICS->value,
+            'active' => false,
+        ]);
+    }
+
+    /**
+     * Test update with partial data
+     */
+    public function test_update_with_partial_data(): void
+    {
+        $committee = AiCommittee::factory()->create([
+            'name' => 'Original Name',
+            'type' => Type::GOVERNANCE->value,
+            'charter' => 'Original Charter',
+        ]);
+
+        $updateData = [
+            'name' => 'Updated Name',
+        ];
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/ai-committees/'.$committee->id, $updateData);
+
+        $response->assertOk()
+            ->assertJsonPath('data.name', 'Updated Name')
+            ->assertJsonPath('data.type', Type::GOVERNANCE->value)
+            ->assertJsonPath('data.charter', 'Original Charter');
+    }
+
+    /**
+     * Test update validates type enum
+     */
+    public function test_update_validates_type_enum(): void
+    {
+        $committee = AiCommittee::factory()->create();
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/ai-committees/'.$committee->id, [
+                'type' => 'invalid_type',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['type']);
+    }
+
+    /**
+     * Test update validates cadence enum
+     */
+    public function test_update_validates_cadence_enum(): void
+    {
+        $committee = AiCommittee::factory()->create();
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/ai-committees/'.$committee->id, [
+                'cadence' => 'invalid_cadence',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['cadence']);
+    }
+
+    /**
+     * Test update with empty data succeeds
+     */
+    public function test_update_with_empty_data_succeeds(): void
+    {
+        $committee = AiCommittee::factory()->create([
+            'name' => 'Original Name',
+        ]);
+
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/ai-committees/'.$committee->id, []);
+
+        $response->assertOk()
+            ->assertJsonPath('data.name', 'Original Name');
+    }
+
+    /**
+     * Test update with all type enum values
+     */
+    public function test_update_with_all_type_values(): void
+    {
+        $committee = AiCommittee::factory()->create();
+
+        foreach (Type::cases() as $type) {
+            $response = $this->actingAs($this->user)
+                ->postJson('/api/ai-committees/'.$committee->id, [
+                    'type' => $type->value,
+                ]);
+
+            $response->assertOk()
+                ->assertJsonPath('data.type', $type->value);
+        }
+    }
+
+    /**
+     * Test update returns 404 for non-existent committee
+     */
+    public function test_update_returns_404_for_nonexistent(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->postJson('/api/ai-committees/99999', [
+                'name' => 'Updated Name',
+            ]);
+
+        $response->assertNotFound();
+    }
+
+    /**
+     * Test unauthenticated user cannot update
+     */
+    public function test_unauthenticated_user_cannot_update(): void
+    {
+        $committee = AiCommittee::factory()->create();
+
+        $response = $this->postJson('/api/ai-committees/'.$committee->id, [
+            'name' => 'Updated Name',
+        ]);
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * Test destroy deletes committee
+     */
+    public function test_destroy_deletes_committee(): void
+    {
+        $committee = AiCommittee::factory()->create();
+        $id = $committee->id;
+
+        $response = $this->actingAs($this->user)
+            ->deleteJson('/api/ai-committees/'.$id);
+
+        $response->assertOk()
+            ->assertJsonPath('error', false)
+            ->assertJsonPath('message', 'AI Committee deleted successfully.')
+            ->assertJsonPath('data', null);
+
+        $this->assertNull(AiCommittee::find($id));
+    }
+
+    /**
+     * Test destroy returns 404 for non-existent committee
+     */
+    public function test_destroy_returns_404_for_nonexistent(): void
+    {
+        $response = $this->actingAs($this->user)
+            ->deleteJson('/api/ai-committees/99999');
+
+        $response->assertNotFound();
+    }
+
+    /**
+     * Test unauthenticated user cannot destroy
+     */
+    public function test_unauthenticated_user_cannot_destroy(): void
+    {
+        $committee = AiCommittee::factory()->create();
+
+        $response = $this->deleteJson('/api/ai-committees/'.$committee->id);
+
+        $response->assertUnauthorized();
+    }
+
+    /**
+     * Test destroy removes committee from database
+     */
+    public function test_destroy_removes_from_database(): void
+    {
+        $committee = AiCommittee::factory()->create(['name' => 'Test Committee']);
+
+        $this->assertDatabaseHas('ai_committees', ['id' => $committee->id]);
+
+        $this->actingAs($this->user)->deleteJson('/api/ai-committees/'.$committee->id);
+
+        $this->assertDatabaseMissing('ai_committees', ['id' => $committee->id]);
+    }
+
+    /**
+     * Test update preserves created_at timestamp
+     */
+    public function test_update_preserves_created_at(): void
+    {
+        $committee = AiCommittee::factory()->create();
+        $originalCreatedAt = $committee->created_at;
+
+        sleep(1); // Ensure time passes
+
+        $this->actingAs($this->user)
+            ->postJson('/api/ai-committees/'.$committee->id, [
+                'name' => 'Updated Name',
+            ]);
+
+        $updated = AiCommittee::find($committee->id);
+        $this->assertEquals($originalCreatedAt->getTimestamp(), $updated->created_at->getTimestamp());
+    }
+
+    /**
+     * Test multiple committees can be stored
+     */
+    public function test_multiple_committees_can_be_stored(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $data = [
+                'name' => "Committee $i",
+                'type' => Type::cases()[$i % count(Type::cases())]->value,
+                'charter' => "Charter $i",
+                'cadence' => Cadence::cases()[$i % count(Cadence::cases())]->value,
+                'owner_team' => "Team $i",
+                'active' => $i % 2 === 0,
+            ];
+
+            $response = $this->actingAs($this->user)->postJson('/api/ai-committees', $data);
+
+            $response->assertCreated();
+        }
+
+        $this->assertDatabaseCount('ai_committees', 5);
+    }
+}

--- a/tests/Unit/AiCommitteeRepositoryTest.php
+++ b/tests/Unit/AiCommitteeRepositoryTest.php
@@ -1,0 +1,550 @@
+<?php
+
+namespace Tests\Unit;
+
+use Tests\TestCase;
+use App\Models\AiCommittee;
+use App\Enums\AiCommittee\Type;
+use App\Enums\AiCommittee\Cadence;
+use App\Repositories\AiCommitteeRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class AiCommitteeRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private AiCommitteeRepository $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repository = app(AiCommitteeRepository::class);
+    }
+
+    /**
+     * Test getting filtered committees with default pagination
+     */
+    public function test_get_filtered_committees_with_default_pagination(): void
+    {
+        AiCommittee::factory(20)->create();
+
+        $result = $this->repository->getFilteredCommittees([]);
+
+        $this->assertEquals(15, $result->count());
+        $this->assertEquals(20, $result->total());
+    }
+
+    /**
+     * Test getting filtered committees with custom per_page
+     */
+    public function test_get_filtered_committees_with_custom_per_page(): void
+    {
+        AiCommittee::factory(25)->create();
+
+        $result = $this->repository->getFilteredCommittees(['per_page' => 10]);
+
+        $this->assertEquals(10, $result->count());
+        $this->assertEquals(25, $result->total());
+    }
+
+    /**
+     * Test filtering by type
+     */
+    public function test_filter_by_type(): void
+    {
+        AiCommittee::factory(5)->create(['type' => Type::GOVERNANCE->value]);
+        AiCommittee::factory(3)->create(['type' => Type::ETHICS->value]);
+        AiCommittee::factory(2)->create(['type' => Type::RISK->value]);
+
+        $result = $this->repository->getFilteredCommittees([
+            'type' => Type::GOVERNANCE->value,
+        ]);
+
+        $this->assertEquals(5, $result->total());
+        $this->assertTrue($result->every(fn ($committee) => $committee->type === Type::GOVERNANCE->value));
+    }
+
+    /**
+     * Test filtering by cadence
+     */
+    public function test_filter_by_cadence(): void
+    {
+        AiCommittee::factory(4)->create(['cadence' => Cadence::MONTHLY->value]);
+        AiCommittee::factory(6)->create(['cadence' => Cadence::QUARTERLY->value]);
+
+        $result = $this->repository->getFilteredCommittees([
+            'cadence' => Cadence::MONTHLY->value,
+        ]);
+
+        $this->assertEquals(4, $result->total());
+        $this->assertTrue($result->every(fn ($committee) => $committee->cadence === Cadence::MONTHLY->value));
+    }
+
+    /**
+     * Test filtering by active true
+     */
+    public function test_filter_by_active_true(): void
+    {
+        AiCommittee::factory(8)->active()->create();
+        AiCommittee::factory(5)->inactive()->create();
+
+        $result = $this->repository->getFilteredCommittees([
+            'active' => true,
+        ]);
+
+        $this->assertEquals(8, $result->total());
+        $this->assertTrue($result->every(fn ($committee) => $committee->active === true));
+    }
+
+    /**
+     * Test filtering by active false
+     */
+    public function test_filter_by_active_false(): void
+    {
+        AiCommittee::factory(7)->active()->create();
+        AiCommittee::factory(6)->inactive()->create();
+
+        $result = $this->repository->getFilteredCommittees([
+            'active' => false,
+        ]);
+
+        $this->assertEquals(6, $result->total());
+        $this->assertTrue($result->every(fn ($committee) => $committee->active === false));
+    }
+
+    /**
+     * Test filtering by name with partial match
+     */
+    public function test_filter_by_name_with_partial_match(): void
+    {
+        AiCommittee::factory()->create(['name' => 'Governance Committee']);
+        AiCommittee::factory()->create(['name' => 'Ethics Board']);
+        AiCommittee::factory()->create(['name' => 'Risk Management Committee']);
+
+        $result = $this->repository->getFilteredCommittees([
+            'name' => 'Committee',
+        ]);
+
+        $this->assertEquals(2, $result->total());
+    }
+
+    /**
+     * Test filtering by name is case-insensitive
+     */
+    public function test_filter_by_name_is_case_insensitive(): void
+    {
+        AiCommittee::factory()->create(['name' => 'Governance Committee']);
+        AiCommittee::factory()->create(['name' => 'Ethics Board']);
+
+        $result = $this->repository->getFilteredCommittees([
+            'name' => 'governance',
+        ]);
+
+        $this->assertEquals(1, $result->total());
+        $this->assertEquals('Governance Committee', $result->first()->name);
+    }
+
+    /**
+     * Test filtering by name returns nothing when no match
+     */
+    public function test_filter_by_name_no_match(): void
+    {
+        AiCommittee::factory()->create(['name' => 'Governance Committee']);
+
+        $result = $this->repository->getFilteredCommittees([
+            'name' => 'NonExistent',
+        ]);
+
+        $this->assertEquals(0, $result->total());
+    }
+
+    /**
+     * Test filtering by multiple filters combined
+     */
+    public function test_filter_by_multiple_filters(): void
+    {
+        AiCommittee::factory(10)->create([
+            'type' => Type::GOVERNANCE->value,
+            'cadence' => Cadence::MONTHLY->value,
+            'active' => true,
+        ]);
+
+        AiCommittee::factory(5)->create([
+            'type' => Type::GOVERNANCE->value,
+            'cadence' => Cadence::QUARTERLY->value,
+            'active' => true,
+        ]);
+
+        AiCommittee::factory(3)->create([
+            'type' => Type::ETHICS->value,
+            'cadence' => Cadence::MONTHLY->value,
+            'active' => true,
+        ]);
+
+        $result = $this->repository->getFilteredCommittees([
+            'type' => Type::GOVERNANCE->value,
+            'cadence' => Cadence::MONTHLY->value,
+            'active' => true,
+        ]);
+
+        $this->assertEquals(10, $result->total());
+    }
+
+    /**
+     * Test filtering with no matching results
+     */
+    public function test_filter_with_no_matching_results(): void
+    {
+        AiCommittee::factory(5)->create(['type' => Type::GOVERNANCE->value]);
+
+        $result = $this->repository->getFilteredCommittees([
+            'type' => Type::ETHICS->value,
+        ]);
+
+        $this->assertEquals(0, $result->total());
+    }
+
+    /**
+     * Test filter with empty filters array
+     */
+    public function test_filter_with_empty_filters_array(): void
+    {
+        AiCommittee::factory(10)->create();
+
+        $result = $this->repository->getFilteredCommittees([]);
+
+        $this->assertEquals(10, $result->total());
+    }
+
+    /**
+     * Test create committee
+     */
+    public function test_create_committee(): void
+    {
+        $data = [
+            'name' => 'AI Governance Committee',
+            'type' => Type::GOVERNANCE->value,
+            'charter' => 'Committee charter document',
+            'cadence' => Cadence::MONTHLY->value,
+            'owner_team' => 'Executive Team',
+            'active' => true,
+        ];
+
+        $committee = $this->repository->createCommittee($data);
+
+        $this->assertInstanceOf(AiCommittee::class, $committee);
+        $this->assertEquals('AI Governance Committee', $committee->name);
+        $this->assertEquals(Type::GOVERNANCE->value, $committee->type);
+        $this->assertEquals(Cadence::MONTHLY->value, $committee->cadence);
+        $this->assertTrue($committee->active);
+        $this->assertDatabaseHas('ai_committees', ['name' => 'AI Governance Committee']);
+    }
+
+    /**
+     * Test create committee with minimal data
+     */
+    public function test_create_committee_with_minimal_data(): void
+    {
+        $data = [
+            'name' => 'Ethics Committee',
+            'type' => Type::ETHICS->value,
+            'charter' => 'Basic charter',
+            'cadence' => Cadence::QUARTERLY->value,
+            'owner_team' => 'Chief Ethics Officer',
+            'active' => false,
+        ];
+
+        $committee = $this->repository->createCommittee($data);
+
+        $this->assertNotNull($committee->id);
+        $this->assertEquals('Ethics Committee', $committee->name);
+        $this->assertFalse($committee->active);
+    }
+
+    /**
+     * Test create committee returns instance with id
+     */
+    public function test_create_committee_returns_instance_with_id(): void
+    {
+        $data = [
+            'name' => 'Risk Committee',
+            'type' => Type::RISK->value,
+            'charter' => 'Risk charter',
+            'cadence' => Cadence::BIWEEKLY->value,
+            'owner_team' => 'Risk Team',
+            'active' => true,
+        ];
+
+        $committee = $this->repository->createCommittee($data);
+
+        $this->assertNotNull($committee->id);
+        $this->assertTrue($committee->id > 0);
+    }
+
+    /**
+     * Test create multiple committees
+     */
+    public function test_create_multiple_committees(): void
+    {
+        $data1 = [
+            'name' => 'Committee 1',
+            'type' => Type::GOVERNANCE->value,
+            'charter' => 'Charter 1',
+            'cadence' => Cadence::MONTHLY->value,
+            'owner_team' => 'Team 1',
+            'active' => true,
+        ];
+
+        $data2 = [
+            'name' => 'Committee 2',
+            'type' => Type::ETHICS->value,
+            'charter' => 'Charter 2',
+            'cadence' => Cadence::QUARTERLY->value,
+            'owner_team' => 'Team 2',
+            'active' => false,
+        ];
+
+        $committee1 = $this->repository->createCommittee($data1);
+        $committee2 = $this->repository->createCommittee($data2);
+
+        $this->assertNotEquals($committee1->id, $committee2->id);
+        $this->assertEquals(2, AiCommittee::count());
+    }
+
+    /**
+     * Test update committee with full data
+     */
+    public function test_update_committee_full(): void
+    {
+        $committee = AiCommittee::factory()->create([
+            'type' => Type::GOVERNANCE->value,
+            'cadence' => Cadence::MONTHLY->value,
+            'active' => true,
+        ]);
+
+        $updateData = [
+            'name' => 'Updated Committee Name',
+            'type' => Type::ETHICS->value,
+            'cadence' => Cadence::QUARTERLY->value,
+            'active' => false,
+        ];
+
+        $updated = $this->repository->updateCommittee($committee, $updateData);
+
+        $this->assertEquals('Updated Committee Name', $updated->name);
+        $this->assertEquals(Type::ETHICS->value, $updated->type);
+        $this->assertEquals(Cadence::QUARTERLY->value, $updated->cadence);
+        $this->assertFalse($updated->active);
+    }
+
+    /**
+     * Test update committee with partial data
+     */
+    public function test_update_committee_partial(): void
+    {
+        $originalName = 'Original Name';
+        $committee = AiCommittee::factory()->create([
+            'name' => $originalName,
+            'type' => Type::GOVERNANCE->value,
+            'active' => true,
+        ]);
+
+        $updateData = [
+            'active' => false,
+        ];
+
+        $updated = $this->repository->updateCommittee($committee, $updateData);
+
+        $this->assertEquals($originalName, $updated->name);
+        $this->assertEquals(Type::GOVERNANCE->value, $updated->type);
+        $this->assertFalse($updated->active);
+    }
+
+    /**
+     * Test update committee returns fresh instance
+     */
+    public function test_update_returns_fresh_instance(): void
+    {
+        $committee = AiCommittee::factory()->create([
+            'name' => 'Original Name',
+            'active' => true,
+        ]);
+
+        $updated = $this->repository->updateCommittee($committee, [
+            'name' => 'Updated Name',
+            'active' => false,
+        ]);
+
+        $this->assertNotSame($committee, $updated);
+        $this->assertEquals('Updated Name', $updated->name);
+        $this->assertFalse($updated->active);
+    }
+
+    /**
+     * Test update committee persists to database
+     */
+    public function test_update_committee_persists_to_database(): void
+    {
+        $committee = AiCommittee::factory()->create([
+            'name' => 'Original',
+            'active' => true,
+        ]);
+
+        $this->repository->updateCommittee($committee, [
+            'name' => 'Updated',
+            'active' => false,
+        ]);
+
+        $this->assertDatabaseHas('ai_committees', [
+            'id' => $committee->id,
+            'name' => 'Updated',
+            'active' => false,
+        ]);
+    }
+
+    /**
+     * Test update preserves unmodified fields
+     */
+    public function test_update_preserves_unmodified_fields(): void
+    {
+        $originalCharter = 'Original Charter';
+        $committee = AiCommittee::factory()->create([
+            'name' => 'Original Name',
+            'charter' => $originalCharter,
+            'type' => Type::GOVERNANCE->value,
+        ]);
+
+        $updated = $this->repository->updateCommittee($committee, [
+            'name' => 'Updated Name',
+        ]);
+
+        $this->assertEquals($originalCharter, $updated->charter);
+        $this->assertEquals(Type::GOVERNANCE->value, $updated->type);
+    }
+
+    /**
+     * Test update with all type enum values
+     */
+    public function test_update_with_all_type_enum_values(): void
+    {
+        $committee = AiCommittee::factory()->create(['type' => Type::GOVERNANCE->value]);
+
+        foreach (Type::cases() as $type) {
+            $updated = $this->repository->updateCommittee($committee, [
+                'type' => $type->value,
+            ]);
+
+            $this->assertEquals($type->value, $updated->type);
+        }
+    }
+
+    /**
+     * Test update with all cadence enum values
+     */
+    public function test_update_with_all_cadence_enum_values(): void
+    {
+        $committee = AiCommittee::factory()->create(['cadence' => Cadence::MONTHLY->value]);
+
+        foreach (Cadence::cases() as $cadence) {
+            $updated = $this->repository->updateCommittee($committee, [
+                'cadence' => $cadence->value,
+            ]);
+
+            $this->assertEquals($cadence->value, $updated->cadence);
+        }
+    }
+
+    /**
+     * Test delete committee
+     */
+    public function test_delete_committee(): void
+    {
+        $committee = AiCommittee::factory()->create();
+        $id = $committee->id;
+
+        $result = $this->repository->deleteCommittee($committee);
+
+        $this->assertTrue($result);
+        $this->assertNull(AiCommittee::find($id));
+    }
+
+    /**
+     * Test delete returns true for successful deletion
+     */
+    public function test_delete_returns_true_on_success(): void
+    {
+        $committee = AiCommittee::factory()->create();
+
+        $result = $this->repository->deleteCommittee($committee);
+
+        $this->assertTrue($result);
+        $this->assertIsBool($result);
+    }
+
+    /**
+     * Test delete non-existent committee returns false
+     */
+    public function test_delete_returns_false_for_already_deleted(): void
+    {
+        $committee = AiCommittee::factory()->create();
+        $committee->delete();
+
+        $result = $this->repository->deleteCommittee($committee);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * Test filter with combination of type and name
+     */
+    public function test_filter_by_type_and_name_combination(): void
+    {
+        AiCommittee::factory()->create([
+            'name' => 'Governance Committee',
+            'type' => Type::GOVERNANCE->value,
+        ]);
+        AiCommittee::factory()->create([
+            'name' => 'Governance Board',
+            'type' => Type::ETHICS->value,
+        ]);
+        AiCommittee::factory()->create([
+            'name' => 'Ethics Committee',
+            'type' => Type::ETHICS->value,
+        ]);
+
+        $result = $this->repository->getFilteredCommittees([
+            'type' => Type::ETHICS->value,
+            'name' => 'Committee',
+        ]);
+
+        $this->assertEquals(1, $result->total());
+        $this->assertEquals('Ethics Committee', $result->first()->name);
+    }
+
+    /**
+     * Test filter pagination data structure
+     */
+    public function test_filter_pagination_data_structure(): void
+    {
+        AiCommittee::factory(25)->create();
+
+        $result = $this->repository->getFilteredCommittees(['per_page' => 10]);
+
+        $this->assertNotNull($result->currentPage());
+        $this->assertNotNull($result->perPage());
+        $this->assertNotNull($result->total());
+        $this->assertTrue($result->hasPages());
+    }
+
+    /**
+     * Test filter returns paginator instance
+     */
+    public function test_filter_returns_paginator_instance(): void
+    {
+        AiCommittee::factory(5)->create();
+
+        $result = $this->repository->getFilteredCommittees([]);
+
+        $this->assertInstanceOf(\Illuminate\Pagination\LengthAwarePaginator::class, $result);
+    }
+}


### PR DESCRIPTION
- Created migration for `ai_committees` table with necessary fields.
- Implemented API routes for managing AI Committees (CRUD operations).
- Developed `AiCommitteeController` with methods for handling requests.
- Added comprehensive feature tests for `AiCommitteeController` to ensure correct functionality.
- Created unit tests for `AiCommitteeRepository` to validate data handling and filtering logic.
- Implemented filtering capabilities for AI Committees based on various criteria (type, cadence, active status, name).
- Ensured validation for required fields and data types during creation and updates.