### PR TITLE
feat: Enhance DatasetSnapshot model and resource with new fields

### DIFF
--- a/app/Enums/DatasetSnapshot/ApprovedBy.php
+++ b/app/Enums/DatasetSnapshot/ApprovedBy.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums\DatasetSnapshot;
+
+enum ApprovedBy: string
+{
+    case DATA_ENGINEERING_TEAM = 'data_engineering_team';
+    case ML_PLATFORM_TEAM = 'ml_platform_team';
+    case PRIVACY_OFFICE = 'privacy_office';
+    case AI_GOVERNANCE_BOARD = 'ai_governance_board';
+}

--- a/app/Enums/DatasetSnapshot/Compression.php
+++ b/app/Enums/DatasetSnapshot/Compression.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums\DatasetSnapshot;
+
+enum Compression: string
+{
+    case GZIP = 'gzip';
+    case SNAPPY = 'snappy';
+    case LZ4 = 'lz4';
+    case ZSTD = 'zstd';
+    case NONE = 'none';
+}

--- a/app/Enums/DatasetSnapshot/EncryptionStatus.php
+++ b/app/Enums/DatasetSnapshot/EncryptionStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums\DatasetSnapshot;
+
+enum EncryptionStatus: string
+{
+    case ENCRYPTED_AT_REST = 'encrypted_at_rest';
+    case ENCRYPTED_AT_TRANSIT = 'encrypted_at_transit';
+    case ENCRYPTED_AT_REST_AND_TRANSIT = 'encrypted_at_rest_and_transit';
+    case UNENCRYPTED = 'unencrypted';
+    case NONE = 'none';
+}

--- a/app/Enums/DatasetSnapshot/FileFormat.php
+++ b/app/Enums/DatasetSnapshot/FileFormat.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums\DatasetSnapshot;
+
+enum FileFormat: string
+{
+    case PARQUET = 'parquet';
+    case JSON = 'json';
+    case CSV = 'csv';
+    case XML = 'xml';
+    case AVRO = 'avro';
+    case ORC = 'orc';
+    case DELTA_LAKE = 'delta_lake';
+    case APACHE_ICEBERG = 'apache_iceberg';
+    case XLSX = 'xlsx';
+    case OTHER = 'other';
+}

--- a/app/Enums/DatasetSnapshot/MaskingMethod.php
+++ b/app/Enums/DatasetSnapshot/MaskingMethod.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums\DatasetSnapshot;
+
+enum MaskingMethod: string
+{
+    case NONE = 'none';
+    case TOKENIZATION = 'tokenization';
+    case HASHING = 'hashing';
+    case ENCRYPTION = 'encryption';
+    case BASE64_ENCODE = 'base64_encode';
+    case REDACTION = 'redaction';
+    case GENERALIZATION = 'generalization';
+    case PSEUDONYMIZATION = 'pseudonymization';
+    case DIFFERENTIAL_PRIVACY = 'differential_privacy';
+    case K_ANONYMIZATION = 'k_anonymization';
+}

--- a/app/Enums/DatasetSnapshot/Status.php
+++ b/app/Enums/DatasetSnapshot/Status.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums\DatasetSnapshot;
+
+enum Status: string
+{
+    case ACTIVE = 'active';
+    case DEPRECATED = 'deprecated';
+    case ARCHIVED = 'archived';
+}

--- a/app/Enums/DatasetSnapshot/StorageTier.php
+++ b/app/Enums/DatasetSnapshot/StorageTier.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums\DatasetSnapshot;
+
+enum StorageTier: string
+{
+    case HOT = 'hot';
+    case COLD = 'cold';
+    case WARM = 'warm';
+    case ARCHIVE = 'archive';
+}

--- a/app/Http/Requests/DatasetSnapshot/StoreDatasetSnapshotRequest.php
+++ b/app/Http/Requests/DatasetSnapshot/StoreDatasetSnapshotRequest.php
@@ -2,9 +2,16 @@
 
 namespace App\Http\Requests\DatasetSnapshot;
 
-use App\Enums\DatasetSnapshot\ResidencyZone;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use App\Enums\DatasetSnapshot\Status;
+use App\Enums\DatasetSnapshot\ApprovedBy;
+use App\Enums\DatasetSnapshot\FileFormat;
+use App\Enums\DatasetSnapshot\Compression;
+use App\Enums\DatasetSnapshot\StorageTier;
+use Illuminate\Foundation\Http\FormRequest;
+use App\Enums\DatasetSnapshot\MaskingMethod;
+use App\Enums\DatasetSnapshot\ResidencyZone;
+use App\Enums\DatasetSnapshot\EncryptionStatus;
 
 class StoreDatasetSnapshotRequest extends FormRequest
 {
@@ -18,17 +25,28 @@ class StoreDatasetSnapshotRequest extends FormRequest
         return [
             'dataset_id' => ['required', 'integer', 'exists:datasets,id'],
             'version_tag' => ['required', 'string', 'max:50'],
-            'time_range_start' => ['nullable', 'date'],
-            'time_range_end' => ['nullable', 'date', 'after_or_equal:time_range_start'],
-            'row_count' => ['nullable', 'integer', 'min:0'],
-            'quality_checksums' => ['nullable', 'string', 'max:255'],
+            'supersedes_snapshot_id' => ['nullable', 'integer', 'exists:dataset_snapshots,id'],
+            'description' => ['nullable', 'string'],
+            'time_range_start' => ['required', 'date'],
+            'time_range_end' => ['required', 'date', 'after_or_equal:time_range_start'],
+            'row_count' => ['required', 'integer', 'min:0'],
+            'file_count' => ['nullable', 'integer', 'min:0'],
+            'total_size' => ['nullable', 'integer', 'min:0'],
+            'size_unit' => ['nullable', 'string', 'max:20'],
+            'file_format' => ['required', Rule::enum(FileFormat::class)],
             'pii_element_count' => ['nullable', 'integer', 'min:0'],
-            'special_category_element_count' => ['nullable', 'integer', 'min:0'],
-            'masking_anonymization_method' => ['nullable', 'string', 'max:255'],
-            'privacy_transform_evidence_ref' => ['nullable', 'string', 'max:255'],
-            'residency_zone' => ['required', Rule::in(array_map(fn($zone) => $zone->value, ResidencyZone::cases()))],
+            'consent_coverage_at_creation' => ['nullable', 'integer', 'min:0', 'max:100'],
+            'residency_zone' => ['required', Rule::enum(ResidencyZone::class)],
             'storage_uri' => ['required', 'string', 'max:500'],
-            'source_created_at' => ['required', 'date'],
+            'storage_tier' => ['nullable', Rule::enum(StorageTier::class)],
+            'compression' => ['nullable', Rule::enum(Compression::class)],
+            'encryption_status' => ['required', Rule::enum(EncryptionStatus::class)],
+            'masking_method_applied' => ['nullable', Rule::enum(MaskingMethod::class)],
+            'quality_checksums' => ['nullable', 'string', 'max:255'],
+            'created_by_system' => ['nullable', 'boolean'],
+            'approved_by' => ['nullable', Rule::enum(ApprovedBy::class)],
+            'expiration_date' => ['nullable', 'date', 'after:today'],
+            'status' => ['required', Rule::enum(Status::class)],
         ];
     }
 }

--- a/app/Http/Requests/DatasetSnapshot/UpdateDatasetSnapshotRequest.php
+++ b/app/Http/Requests/DatasetSnapshot/UpdateDatasetSnapshotRequest.php
@@ -2,9 +2,16 @@
 
 namespace App\Http\Requests\DatasetSnapshot;
 
-use App\Enums\DatasetSnapshot\ResidencyZone;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use App\Enums\DatasetSnapshot\Status;
+use App\Enums\DatasetSnapshot\ApprovedBy;
+use App\Enums\DatasetSnapshot\FileFormat;
+use App\Enums\DatasetSnapshot\Compression;
+use App\Enums\DatasetSnapshot\StorageTier;
+use Illuminate\Foundation\Http\FormRequest;
+use App\Enums\DatasetSnapshot\MaskingMethod;
+use App\Enums\DatasetSnapshot\ResidencyZone;
+use App\Enums\DatasetSnapshot\EncryptionStatus;
 
 class UpdateDatasetSnapshotRequest extends FormRequest
 {
@@ -16,18 +23,30 @@ class UpdateDatasetSnapshotRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'dataset_id' => ['sometimes', 'integer', 'exists:datasets,id'],
             'version_tag' => ['sometimes', 'string', 'max:50'],
-            'time_range_start' => ['nullable', 'date'],
-            'time_range_end' => ['nullable', 'date', 'after_or_equal:time_range_start'],
-            'row_count' => ['nullable', 'integer', 'min:0'],
-            'quality_checksums' => ['nullable', 'string', 'max:255'],
+            'supersedes_snapshot_id' => ['nullable', 'integer', 'exists:dataset_snapshots,id'],
+            'description' => ['nullable', 'string'],
+            'time_range_start' => ['sometimes', 'date'],
+            'time_range_end' => ['sometimes', 'date', 'after_or_equal:time_range_start'],
+            'row_count' => ['sometimes', 'integer', 'min:0'],
+            'file_count' => ['nullable', 'integer', 'min:0'],
+            'total_size' => ['nullable', 'integer', 'min:0'],
+            'size_unit' => ['nullable', 'string', 'max:20'],
+            'file_format' => ['sometimes', Rule::enum(FileFormat::class)],
             'pii_element_count' => ['nullable', 'integer', 'min:0'],
-            'special_category_element_count' => ['nullable', 'integer', 'min:0'],
-            'masking_anonymization_method' => ['nullable', 'string', 'max:255'],
-            'privacy_transform_evidence_ref' => ['nullable', 'string', 'max:255'],
-            'residency_zone' => ['sometimes', Rule::in(array_map(fn($zone) => $zone->value, ResidencyZone::cases()))],
+            'consent_coverage_at_creation' => ['nullable', 'integer', 'min:0', 'max:100'],
+            'residency_zone' => ['sometimes', Rule::enum(ResidencyZone::class)],
             'storage_uri' => ['sometimes', 'string', 'max:500'],
-            'source_created_at' => ['sometimes', 'date'],
+            'storage_tier' => ['nullable', Rule::enum(StorageTier::class)],
+            'compression' => ['nullable', Rule::enum(Compression::class)],
+            'encryption_status' => ['sometimes', Rule::enum(EncryptionStatus::class)],
+            'masking_method_applied' => ['nullable', Rule::enum(MaskingMethod::class)],
+            'quality_checksums' => ['nullable', 'string', 'max:255'],
+            'created_by_system' => ['nullable', 'boolean'],
+            'approved_by' => ['nullable', Rule::enum(ApprovedBy::class)],
+            'expiration_date' => ['nullable', 'date', 'after:today'],
+            'status' => ['sometimes', Rule::enum(Status::class)],
         ];
     }
 }

--- a/app/Http/Resources/DatasetSnapshotResource.php
+++ b/app/Http/Resources/DatasetSnapshotResource.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Resources;
 
-use App\Models\DatasetSnapshot;
 use Illuminate\Http\Request;
-use Illuminate\Http\Resources\Json\JsonResource;
 use Illuminate\Support\Carbon;
+use App\Models\DatasetSnapshot;
+use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
  * @mixin DatasetSnapshot
@@ -21,17 +21,30 @@ class DatasetSnapshotResource extends JsonResource
     {
         return [
             'id' => $this->id,
+            'dataset_id' => $this->dataset_id,
             'version_tag' => $this->version_tag,
+            'supersedes_snapshot_id' => $this->supersedes_snapshot_id,
+            'description' => $this->description,
             'time_range_start' => $this->time_range_start ? Carbon::parse($this->time_range_start)->toDateTimeString() : null,
             'time_range_end' => $this->time_range_end ? Carbon::parse($this->time_range_end)->toDateTimeString() : null,
             'row_count' => $this->row_count,
-            'quality_checksums' => $this->quality_checksums,
+            'file_count' => $this->file_count,
+            'total_size' => $this->total_size,
+            'size_unit' => $this->size_unit,
+            'file_format' => $this->file_format,
             'pii_element_count' => $this->pii_element_count,
-            'special_category_element_count' => $this->special_category_element_count,
-            'masking_anonymization_method' => $this->masking_anonymization_method,
-            'privacy_transform_evidence_ref' => $this->privacy_transform_evidence_ref,
+            'consent_coverage_at_creation' => $this->consent_coverage_at_creation,
             'residency_zone' => $this->residency_zone,
             'storage_uri' => $this->storage_uri,
+            'storage_tier' => $this->storage_tier,
+            'compression' => $this->compression,
+            'encryption_status' => $this->encryption_status,
+            'masking_method_applied' => $this->masking_method_applied,
+            'quality_checksums' => $this->quality_checksums,
+            'created_by_system' => $this->created_by_system,
+            'approved_by' => $this->approved_by,
+            'expiration_date' => $this->expiration_date ? Carbon::parse($this->expiration_date)->toDateString() : null,
+            'status' => $this->status,
             'created_at' => $this->created_at->toDateTimeString(),
             'updated_at' => $this->updated_at->toDateTimeString(),
             'dataset' => new DatasetResource($this->whenLoaded('dataset')),

--- a/app/Models/DatasetSnapshot.php
+++ b/app/Models/DatasetSnapshot.php
@@ -15,17 +15,28 @@ class DatasetSnapshot extends Model
         'organization_id',
         'dataset_id',
         'version_tag',
+        'supersedes_snapshot_id',
+        'description',
         'time_range_start',
         'time_range_end',
         'row_count',
         'quality_checksums',
         'pii_element_count',
-        'special_category_element_count',
-        'masking_anonymization_method',
-        'privacy_transform_evidence_ref',
+        'consent_coverage_at_creation',
+        'file_count',
+        'total_size',
+        'size_unit',
+        'file_format',
         'residency_zone',
         'storage_uri',
-        'source_created_at',
+        'storage_tier',
+        'compression',
+        'encryption_status',
+        'masking_method_applied',
+        'created_by_system',
+        'approved_by',
+        'expiration_date',
+        'status',
     ];
 
     protected function casts(): array
@@ -33,10 +44,13 @@ class DatasetSnapshot extends Model
         return [
             'time_range_start' => 'datetime',
             'time_range_end' => 'datetime',
+            'expiration_date' => 'date',
             'row_count' => 'integer',
             'pii_element_count' => 'integer',
-            'special_category_element_count' => 'integer',
-            'source_created_at' => 'datetime',
+            'file_count' => 'integer',
+            'total_size' => 'integer',
+            'consent_coverage_at_creation' => 'integer',
+            'created_by_system' => 'boolean',
         ];
     }
 

--- a/database/factories/DatasetSnapshotFactory.php
+++ b/database/factories/DatasetSnapshotFactory.php
@@ -2,10 +2,17 @@
 
 namespace Database\Factories;
 
-use App\Enums\DatasetSnapshot\ResidencyZone;
 use App\Models\Dataset;
-use App\Models\DatasetSnapshot;
 use App\Models\Organization;
+use App\Models\DatasetSnapshot;
+use App\Enums\DatasetSnapshot\Status;
+use App\Enums\DatasetSnapshot\ApprovedBy;
+use App\Enums\DatasetSnapshot\FileFormat;
+use App\Enums\DatasetSnapshot\Compression;
+use App\Enums\DatasetSnapshot\StorageTier;
+use App\Enums\DatasetSnapshot\MaskingMethod;
+use App\Enums\DatasetSnapshot\ResidencyZone;
+use App\Enums\DatasetSnapshot\EncryptionStatus;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -15,32 +22,34 @@ class DatasetSnapshotFactory extends Factory
 {
     protected $model = DatasetSnapshot::class;
 
-    /**
-     * Define the model's default state.
-     *
-     * @return array<string, mixed>
-     */
     public function definition(): array
     {
         return [
             'organization_id' => Organization::factory(),
             'dataset_id' => Dataset::factory(),
             'version_tag' => fake()->randomElement(['v1.0', 'v1.1', 'v2.0', 'v2.1', 'v3.0']),
+            'supersedes_snapshot_id' => null,
+            'description' => fake()->optional()->sentence(),
             'time_range_start' => fake()->optional()->dateTimeBetween('-1 year', '-1 month'),
             'time_range_end' => fake()->optional()->dateTimeBetween('-1 month', 'now'),
             'row_count' => fake()->optional()->numberBetween(1000, 10000000),
-            'quality_checksums' => fake()->optional()->sha256(),
+            'file_count' => fake()->optional()->numberBetween(1, 1000),
+            'total_size' => fake()->optional()->numberBetween(1024, 10737418240), // 1KB to 10GB
+            'size_unit' => fake()->optional()->randomElement(['B', 'KB', 'MB', 'GB', 'TB']),
+            'file_format' => fake()->randomElement(FileFormat::cases())->value,
             'pii_element_count' => fake()->optional()->numberBetween(0, 50),
-            'special_category_element_count' => fake()->optional()->numberBetween(0, 20),
-            'masking_anonymization_method' => fake()->optional()->randomElement([
-                'Full Masking',
-                'Tokenization',
-                'Pseudonymization',
-                'Encryption',
-            ]),
-            'privacy_transform_evidence_ref' => fake()->optional()->regexify('PTE-[0-9]{6}'),
-            'residency_zone' => fake()->randomElement(ResidencyZone::cases()),
-            'storage_uri' => fake()->url() . '/snapshots/' . fake()->regexify('[a-z0-9]{16}'),
+            'consent_coverage_at_creation' => fake()->optional()->numberBetween(0, 100),
+            'residency_zone' => fake()->randomElement(ResidencyZone::cases())->value,
+            'storage_uri' => fake()->url().'/snapshots/'.fake()->regexify('[a-z0-9]{16}'),
+            'storage_tier' => fake()->boolean() ? fake()->randomElement(StorageTier::cases())->value : null,
+            'compression' => fake()->boolean() ? fake()->randomElement(Compression::cases())->value : null,
+            'encryption_status' => fake()->randomElement(EncryptionStatus::cases())->value,
+            'masking_method_applied' => fake()->boolean() ? fake()->randomElement(MaskingMethod::cases())->value : null,
+            'quality_checksums' => fake()->optional()->sha256(),
+            'created_by_system' => fake()->boolean(),
+            'approved_by' => fake()->boolean() ? fake()->randomElement(ApprovedBy::cases())->value : null,
+            'expiration_date' => fake()->optional()->dateTimeBetween('now', '+5 years'),
+            'status' => fake()->randomElement(Status::cases())->value,
         ];
     }
 }

--- a/database/migrations/2025_12_29_121759_modify_dataset_snapshots_table.php
+++ b/database/migrations/2025_12_29_121759_modify_dataset_snapshots_table.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('dataset_snapshots', function (Blueprint $table) {
+            $table->dropColumn([
+                'source_created_at',
+                'special_category_element_count',
+                'masking_anonymization_method',
+                'privacy_transform_evidence_ref',
+            ]);
+
+            $table->unsignedBigInteger('supersedes_snapshot_id')->nullable()->after('version_tag');
+            $table->text('description')->nullable()->after('version_tag');
+            $table->integer('file_count')->nullable()->after('row_count');
+            $table->bigInteger('total_size')->nullable()->after('file_count');
+            $table->string('size_unit')->nullable()->after('total_size');
+            $table->string('file_format')->nullable()->after('size_unit');
+            $table->integer('consent_coverage_at_creation')->nullable()->after('pii_element_count');
+            $table->string('storage_tier')->nullable()->after('residency_zone');
+            $table->string('compression')->nullable()->after('storage_tier');
+            $table->string('encryption_status')->nullable()->after('compression');
+            $table->string('masking_method_applied')->nullable()->after('encryption_status');
+            $table->string('created_by_system')->nullable()->after('masking_method_applied');
+            $table->string('approved_by')->nullable()->after('created_by_system');
+            $table->date('expiration_date')->nullable()->after('approved_by');
+            $table->string('status')->nullable()->after('expiration_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('dataset_snapshots', function (Blueprint $table) {
+            $table->integer('special_category_element_count')->nullable();
+            $table->string('masking_anonymization_method')->nullable();
+            $table->string('privacy_transform_evidence_ref')->nullable();
+            $table->dateTime('source_created_at')->nullable();
+
+            $table->dropColumn([
+                'supersedes_snapshot_id',
+                'description',
+                'file_count',
+                'total_size',
+                'size_unit',
+                'file_format',
+                'consent_coverage_at_creation',
+                'storage_tier',
+                'compression',
+                'encryption_status',
+                'masking_method_applied',
+                'created_by_system',
+                'approved_by',
+                'expiration_date',
+                'status',
+            ]);
+        });
+    }
+};

--- a/tests/Feature/Controllers/User/DatasetSnapshotControllerTest.php
+++ b/tests/Feature/Controllers/User/DatasetSnapshotControllerTest.php
@@ -2,19 +2,27 @@
 
 namespace Tests\Feature\Controllers\User;
 
-use App\Enums\DatasetSnapshot\ResidencyZone;
-use App\Models\Dataset;
-use App\Models\DatasetSnapshot;
-use App\Models\Organization;
-use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\Models\User;
+use App\Models\Dataset;
+use App\Models\Organization;
+use App\Models\DatasetSnapshot;
+use App\Enums\DatasetSnapshot\Status;
+use App\Enums\DatasetSnapshot\ApprovedBy;
+use App\Enums\DatasetSnapshot\FileFormat;
+use App\Enums\DatasetSnapshot\Compression;
+use App\Enums\DatasetSnapshot\StorageTier;
+use App\Enums\DatasetSnapshot\MaskingMethod;
+use App\Enums\DatasetSnapshot\ResidencyZone;
+use App\Enums\DatasetSnapshot\EncryptionStatus;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class DatasetSnapshotControllerTest extends TestCase
 {
     use RefreshDatabase;
 
     private User $user;
+
     private Organization $organization;
 
     protected function setUp(): void
@@ -31,19 +39,31 @@ class DatasetSnapshotControllerTest extends TestCase
         return array_merge([
             'dataset_id' => $dataset->id,
             'version_tag' => 'v1.0',
+            'description' => 'Test dataset snapshot',
             'time_range_start' => '2024-01-01',
             'time_range_end' => '2024-12-31',
             'row_count' => 50000,
-            'quality_checksums' => hash('sha256', 'test'),
+            'file_count' => 120,
+            'total_size' => 5242880,
+            'size_unit' => 'MB',
+            'file_format' => FileFormat::PARQUET->value,
             'pii_element_count' => 10,
-            'special_category_element_count' => 5,
-            'masking_anonymization_method' => 'Tokenization',
-            'privacy_transform_evidence_ref' => 'PTE-123456',
+            'consent_coverage_at_creation' => 95,
             'residency_zone' => ResidencyZone::EU->value,
             'storage_uri' => 'https://storage.example.com/snapshots/abc123',
-            'source_created_at' => '2024-01-15',
+            'storage_tier' => StorageTier::HOT->value,
+            'compression' => Compression::GZIP->value,
+            'encryption_status' => EncryptionStatus::ENCRYPTED_AT_REST->value,
+            'masking_method_applied' => MaskingMethod::TOKENIZATION->value,
+            'quality_checksums' => hash('sha256', 'test'),
+            'created_by_system' => false,
+            'approved_by' => ApprovedBy::PRIVACY_OFFICE->value,
+            'expiration_date' => now()->addYears(1)->toDateString(),
+            'status' => Status::ACTIVE->value,
         ], $overrides);
     }
+
+    // ==================== Index Tests ====================
 
     /**
      * Test user can get paginated dataset snapshots.
@@ -65,23 +85,22 @@ class DatasetSnapshotControllerTest extends TestCase
                             'id',
                             'dataset_id',
                             'version_tag',
+                            'description',
                             'time_range_start',
                             'time_range_end',
                             'row_count',
-                            'quality_checksums',
-                            'pii_element_count',
-                            'special_category_element_count',
-                            'masking_anonymization_method',
-                            'privacy_transform_evidence_ref',
-                            'residency_zone',
-                            'storage_uri',
+                            'file_count',
+                            'total_size',
+                            'file_format',
+                            'encryption_status',
+                            'status',
                             'created_at',
                             'updated_at',
-                        ]
+                        ],
                     ],
                     'per_page',
                     'total',
-                ]
+                ],
             ])
             ->assertJson(['error' => false]);
     }
@@ -99,6 +118,8 @@ class DatasetSnapshotControllerTest extends TestCase
             ->assertJsonPath('data.per_page', 10);
     }
 
+    // ==================== Store Tests ====================
+
     /**
      * Test user can create a dataset snapshot with all fields.
      */
@@ -114,10 +135,14 @@ class DatasetSnapshotControllerTest extends TestCase
                 'message',
                 'data' => [
                     'id',
+                    'dataset_id',
                     'version_tag',
+                    'file_format',
                     'residency_zone',
+                    'encryption_status',
                     'storage_uri',
-                ]
+                    'status',
+                ],
             ])
             ->assertJson([
                 'error' => false,
@@ -127,8 +152,9 @@ class DatasetSnapshotControllerTest extends TestCase
         $this->assertDatabaseHas('dataset_snapshots', [
             'dataset_id' => $payload['dataset_id'],
             'version_tag' => $payload['version_tag'],
-            'residency_zone' => $payload['residency_zone'],
-            'storage_uri' => $payload['storage_uri'],
+            'file_format' => $payload['file_format'],
+            'encryption_status' => $payload['encryption_status'],
+            'status' => $payload['status'],
         ]);
     }
 
@@ -142,9 +168,14 @@ class DatasetSnapshotControllerTest extends TestCase
         $payload = [
             'dataset_id' => $dataset->id,
             'version_tag' => 'v1.0',
+            'time_range_start' => '2024-01-01',
+            'time_range_end' => '2024-12-31',
+            'row_count' => 1000,
+            'file_format' => FileFormat::CSV->value,
             'residency_zone' => ResidencyZone::US->value,
             'storage_uri' => 'https://storage.example.com/snapshots/xyz789',
-            'source_created_at' => '2024-01-15',
+            'encryption_status' => EncryptionStatus::ENCRYPTED_AT_REST->value,
+            'status' => Status::ACTIVE->value,
         ];
 
         $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
@@ -160,6 +191,8 @@ class DatasetSnapshotControllerTest extends TestCase
             'version_tag' => $payload['version_tag'],
         ]);
     }
+
+    // ==================== Validation Tests ====================
 
     /**
      * Test dataset_id is required.
@@ -211,6 +244,152 @@ class DatasetSnapshotControllerTest extends TestCase
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['version_tag']);
+    }
+
+    /**
+     * Test time_range_start is required.
+     */
+    public function test_time_range_start_is_required(): void
+    {
+        $payload = $this->validPayload(['time_range_start' => null]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['time_range_start']);
+    }
+
+    /**
+     * Test time_range_end is required.
+     */
+    public function test_time_range_end_is_required(): void
+    {
+        $payload = $this->validPayload(['time_range_end' => null]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['time_range_end']);
+    }
+
+    /**
+     * Test time_range_end must be after or equal to time_range_start.
+     */
+    public function test_time_range_end_must_be_after_or_equal_to_start(): void
+    {
+        $payload = $this->validPayload([
+            'time_range_start' => '2024-12-31',
+            'time_range_end' => '2024-01-01',
+        ]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['time_range_end']);
+    }
+
+    /**
+     * Test row_count is required.
+     */
+    public function test_row_count_is_required(): void
+    {
+        $payload = $this->validPayload(['row_count' => null]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['row_count']);
+    }
+
+    /**
+     * Test row_count must be non-negative.
+     */
+    public function test_row_count_must_be_non_negative(): void
+    {
+        $payload = $this->validPayload(['row_count' => -1]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['row_count']);
+    }
+
+    /**
+     * Test file_count must be non-negative.
+     */
+    public function test_file_count_must_be_non_negative(): void
+    {
+        $payload = $this->validPayload(['file_count' => -1]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['file_count']);
+    }
+
+    /**
+     * Test total_size must be non-negative.
+     */
+    public function test_total_size_must_be_non_negative(): void
+    {
+        $payload = $this->validPayload(['total_size' => -1]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['total_size']);
+    }
+
+    /**
+     * Test file_format is required.
+     */
+    public function test_file_format_is_required(): void
+    {
+        $payload = $this->validPayload(['file_format' => null]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['file_format']);
+    }
+
+    /**
+     * Test file_format must be valid enum value.
+     */
+    public function test_file_format_must_be_valid_enum(): void
+    {
+        $payload = $this->validPayload(['file_format' => 'INVALID_FORMAT']);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['file_format']);
+    }
+
+    /**
+     * Test pii_element_count must be non-negative.
+     */
+    public function test_pii_element_count_must_be_non_negative(): void
+    {
+        $payload = $this->validPayload(['pii_element_count' => -1]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['pii_element_count']);
+    }
+
+    /**
+     * Test consent_coverage_at_creation must be between 0 and 100.
+     */
+    public function test_consent_coverage_at_creation_max_is_100(): void
+    {
+        $payload = $this->validPayload(['consent_coverage_at_creation' => 101]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['consent_coverage_at_creation']);
     }
 
     /**
@@ -266,59 +445,71 @@ class DatasetSnapshotControllerTest extends TestCase
     }
 
     /**
-     * Test time_range_end must be after or equal to time_range_start.
+     * Test encryption_status is required.
      */
-    public function test_time_range_end_must_be_after_or_equal_to_start(): void
+    public function test_encryption_status_is_required(): void
     {
-        $payload = $this->validPayload([
-            'time_range_start' => '2024-12-31',
-            'time_range_end' => '2024-01-01',
-        ]);
+        $payload = $this->validPayload(['encryption_status' => null]);
 
         $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
 
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['time_range_end']);
+            ->assertJsonValidationErrors(['encryption_status']);
     }
 
     /**
-     * Test row_count must be non-negative.
+     * Test encryption_status must be valid enum value.
      */
-    public function test_row_count_must_be_non_negative(): void
+    public function test_encryption_status_must_be_valid_enum(): void
     {
-        $payload = $this->validPayload(['row_count' => -1]);
+        $payload = $this->validPayload(['encryption_status' => 'INVALID_STATUS']);
 
         $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
 
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['row_count']);
+            ->assertJsonValidationErrors(['encryption_status']);
     }
 
     /**
-     * Test pii_element_count must be non-negative.
+     * Test status is required.
      */
-    public function test_pii_element_count_must_be_non_negative(): void
+    public function test_status_is_required(): void
     {
-        $payload = $this->validPayload(['pii_element_count' => -1]);
+        $payload = $this->validPayload(['status' => null]);
 
         $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
 
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['pii_element_count']);
+            ->assertJsonValidationErrors(['status']);
     }
 
     /**
-     * Test special_category_element_count must be non-negative.
+     * Test status must be valid enum value.
      */
-    public function test_special_category_element_count_must_be_non_negative(): void
+    public function test_status_must_be_valid_enum(): void
     {
-        $payload = $this->validPayload(['special_category_element_count' => -1]);
+        $payload = $this->validPayload(['status' => 'INVALID_STATUS']);
 
         $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
 
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['special_category_element_count']);
+            ->assertJsonValidationErrors(['status']);
     }
+
+    /**
+     * Test quality_checksums max length is 255.
+     */
+    public function test_quality_checksums_max_length_is_255(): void
+    {
+        $payload = $this->validPayload(['quality_checksums' => str_repeat('a', 256)]);
+
+        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['quality_checksums']);
+    }
+
+    // ==================== Show Tests ====================
 
     /**
      * Test user can view a specific dataset snapshot.
@@ -335,17 +526,18 @@ class DatasetSnapshotControllerTest extends TestCase
                 'message',
                 'data' => [
                     'id',
+                    'dataset_id',
                     'version_tag',
-                    'residency_zone',
-                    'storage_uri',
-                ]
+                    'encryption_status',
+                    'status',
+                ],
             ])
             ->assertJson([
                 'error' => false,
                 'data' => [
                     'id' => $snapshot->id,
                     'version_tag' => $snapshot->version_tag,
-                ]
+                ],
             ]);
     }
 
@@ -365,10 +557,12 @@ class DatasetSnapshotControllerTest extends TestCase
                     'dataset' => [
                         'id',
                         'name',
-                    ]
-                ]
+                    ],
+                ],
             ]);
     }
+
+    // ==================== Update Tests ====================
 
     /**
      * Test user can update a dataset snapshot.
@@ -379,12 +573,14 @@ class DatasetSnapshotControllerTest extends TestCase
             'organization_id' => $this->organization->id,
             'version_tag' => 'v1.0',
             'row_count' => 1000,
+            'status' => Status::ACTIVE->value,
         ]);
 
         $updateData = [
             'version_tag' => 'v1.1',
             'row_count' => 1500,
-            'quality_checksums' => hash('sha256', 'updated'),
+            'file_count' => 150,
+            'status' => Status::DEPRECATED->value,
         ];
 
         $response = $this->actingAs($this->user)->postJson("/api/dataset-snapshots/{$snapshot->id}", $updateData);
@@ -396,13 +592,14 @@ class DatasetSnapshotControllerTest extends TestCase
                 'data' => [
                     'version_tag' => 'v1.1',
                     'row_count' => 1500,
-                ]
+                ],
             ]);
 
         $this->assertDatabaseHas('dataset_snapshots', [
             'id' => $snapshot->id,
             'version_tag' => 'v1.1',
             'row_count' => 1500,
+            'file_count' => 150,
         ]);
     }
 
@@ -415,7 +612,7 @@ class DatasetSnapshotControllerTest extends TestCase
             'organization_id' => $this->organization->id,
             'version_tag' => 'v1.0',
             'row_count' => 1000,
-            'residency_zone' => ResidencyZone::EU,
+            'residency_zone' => ResidencyZone::EU->value,
         ]);
 
         $updateData = [
@@ -431,6 +628,33 @@ class DatasetSnapshotControllerTest extends TestCase
             'version_tag' => 'v1.0', // unchanged
             'row_count' => 2000, // updated
             'residency_zone' => ResidencyZone::EU->value, // unchanged
+        ]);
+    }
+
+    /**
+     * Test update can change enum fields.
+     */
+    public function test_update_can_change_enum_fields(): void
+    {
+        $snapshot = DatasetSnapshot::factory()->create([
+            'organization_id' => $this->organization->id,
+            'compression' => Compression::GZIP->value,
+            'status' => Status::ACTIVE->value,
+        ]);
+
+        $updateData = [
+            'compression' => Compression::SNAPPY->value,
+            'status' => Status::ARCHIVED->value,
+        ];
+
+        $response = $this->actingAs($this->user)->postJson("/api/dataset-snapshots/{$snapshot->id}", $updateData);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('dataset_snapshots', [
+            'id' => $snapshot->id,
+            'compression' => Compression::SNAPPY->value,
+            'status' => Status::ARCHIVED->value,
         ]);
     }
 
@@ -452,6 +676,8 @@ class DatasetSnapshotControllerTest extends TestCase
             ->assertJsonValidationErrors(['time_range_end']);
     }
 
+    // ==================== Delete Tests ====================
+
     /**
      * Test user can delete a dataset snapshot.
      */
@@ -470,6 +696,8 @@ class DatasetSnapshotControllerTest extends TestCase
 
         $this->assertDatabaseMissing('dataset_snapshots', ['id' => $snapshot->id]);
     }
+
+    // ==================== Authentication Tests ====================
 
     /**
      * Test unauthenticated user cannot access index.
@@ -527,44 +755,5 @@ class DatasetSnapshotControllerTest extends TestCase
         $response = $this->deleteJson("/api/dataset-snapshots/{$snapshot->id}");
 
         $response->assertStatus(401);
-    }
-
-    /**
-     * Test quality_checksums max length is 255.
-     */
-    public function test_quality_checksums_max_length_is_255(): void
-    {
-        $payload = $this->validPayload(['quality_checksums' => str_repeat('a', 256)]);
-
-        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
-
-        $response->assertStatus(422)
-            ->assertJsonValidationErrors(['quality_checksums']);
-    }
-
-    /**
-     * Test masking_anonymization_method max length is 255.
-     */
-    public function test_masking_anonymization_method_max_length_is_255(): void
-    {
-        $payload = $this->validPayload(['masking_anonymization_method' => str_repeat('a', 256)]);
-
-        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
-
-        $response->assertStatus(422)
-            ->assertJsonValidationErrors(['masking_anonymization_method']);
-    }
-
-    /**
-     * Test privacy_transform_evidence_ref max length is 255.
-     */
-    public function test_privacy_transform_evidence_ref_max_length_is_255(): void
-    {
-        $payload = $this->validPayload(['privacy_transform_evidence_ref' => str_repeat('a', 256)]);
-
-        $response = $this->actingAs($this->user)->postJson('/api/dataset-snapshots', $payload);
-
-        $response->assertStatus(422)
-            ->assertJsonValidationErrors(['privacy_transform_evidence_ref']);
     }
 }

--- a/tests/Feature/Repositories/DatasetSnapshotRepositoryTest.php
+++ b/tests/Feature/Repositories/DatasetSnapshotRepositoryTest.php
@@ -2,13 +2,20 @@
 
 namespace Tests\Feature\Repositories;
 
-use App\Enums\DatasetSnapshot\ResidencyZone;
+use Tests\TestCase;
 use App\Models\Dataset;
-use App\Models\DatasetSnapshot;
 use App\Models\Organization;
+use App\Models\DatasetSnapshot;
+use App\Enums\DatasetSnapshot\Status;
+use App\Enums\DatasetSnapshot\ApprovedBy;
+use App\Enums\DatasetSnapshot\FileFormat;
+use App\Enums\DatasetSnapshot\Compression;
+use App\Enums\DatasetSnapshot\StorageTier;
+use App\Enums\DatasetSnapshot\MaskingMethod;
+use App\Enums\DatasetSnapshot\ResidencyZone;
+use App\Enums\DatasetSnapshot\EncryptionStatus;
 use App\Repositories\DatasetSnapshotRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
 class DatasetSnapshotRepositoryTest extends TestCase
 {
@@ -19,7 +26,7 @@ class DatasetSnapshotRepositoryTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->repository = new DatasetSnapshotRepository();
+        $this->repository = new DatasetSnapshotRepository;
     }
 
     /**
@@ -190,7 +197,7 @@ class DatasetSnapshotRepositoryTest extends TestCase
     }
 
     /**
-     * Test create snapshot creates a new snapshot.
+     * Test create snapshot creates a new snapshot with all required fields.
      */
     public function test_create_snapshot_creates_new_snapshot(): void
     {
@@ -201,16 +208,28 @@ class DatasetSnapshotRepositoryTest extends TestCase
             'organization_id' => $organization->id,
             'dataset_id' => $dataset->id,
             'version_tag' => 'v1.0',
+            'supersedes_snapshot_id' => null,
+            'description' => 'Test dataset snapshot',
             'time_range_start' => now()->subMonths(3),
             'time_range_end' => now(),
             'row_count' => 50000,
-            'quality_checksums' => hash('sha256', 'test'),
+            'file_count' => 120,
+            'total_size' => 5242880,
+            'size_unit' => 'MB',
+            'file_format' => FileFormat::PARQUET->value,
             'pii_element_count' => 10,
-            'special_category_element_count' => 5,
-            'masking_anonymization_method' => 'Tokenization',
-            'privacy_transform_evidence_ref' => 'PTE-123456',
-            'residency_zone' => ResidencyZone::EU,
+            'consent_coverage_at_creation' => 95,
+            'residency_zone' => ResidencyZone::EU->value,
             'storage_uri' => 'https://storage.example.com/snapshots/abc123',
+            'storage_tier' => StorageTier::HOT->value,
+            'compression' => Compression::GZIP->value,
+            'encryption_status' => EncryptionStatus::ENCRYPTED_AT_REST->value,
+            'masking_method_applied' => MaskingMethod::TOKENIZATION->value,
+            'quality_checksums' => hash('sha256', 'test'),
+            'created_by_system' => false,
+            'approved_by' => ApprovedBy::PRIVACY_OFFICE->value,
+            'expiration_date' => now()->addYears(1),
+            'status' => Status::ACTIVE->value,
         ];
 
         $result = $this->repository->createSnapshot($data);
@@ -219,9 +238,14 @@ class DatasetSnapshotRepositoryTest extends TestCase
         $this->assertEquals($data['version_tag'], $result->version_tag);
         $this->assertEquals($data['dataset_id'], $result->dataset_id);
         $this->assertEquals($data['row_count'], $result->row_count);
-        $this->assertEquals($data['residency_zone'], $result->residency_zone);
+        $this->assertEquals($data['file_count'], $result->file_count);
+        $this->assertEquals($data['total_size'], $result->total_size);
+        $this->assertEquals($data['file_format'], $result->file_format);
+        $this->assertEquals($data['encryption_status'], $result->encryption_status);
+        $this->assertEquals($data['status'], $result->status);
         $this->assertDatabaseHas('dataset_snapshots', [
             'version_tag' => 'v1.0',
+            'file_format' => FileFormat::PARQUET->value,
         ]);
     }
 
@@ -237,32 +261,46 @@ class DatasetSnapshotRepositoryTest extends TestCase
             'organization_id' => $organization->id,
             'dataset_id' => $dataset->id,
             'version_tag' => 'v1.0',
-            'residency_zone' => ResidencyZone::US,
+            'time_range_start' => now()->subMonths(1),
+            'time_range_end' => now(),
+            'row_count' => 1000,
+            'residency_zone' => ResidencyZone::US->value,
             'storage_uri' => 'https://storage.example.com/snapshots/xyz789',
+            'encryption_status' => EncryptionStatus::ENCRYPTED_AT_REST->value,
+            'status' => Status::ACTIVE->value,
+            'file_format' => FileFormat::CSV->value,
         ];
 
         $result = $this->repository->createSnapshot($data);
 
         $this->assertInstanceOf(DatasetSnapshot::class, $result);
-        $this->assertNull($result->time_range_start);
-        $this->assertNull($result->time_range_end);
-        $this->assertNull($result->row_count);
+        $this->assertEquals($data['version_tag'], $result->version_tag);
+        $this->assertEquals($data['dataset_id'], $result->dataset_id);
+        $this->assertNull($result->file_count);
+        $this->assertNull($result->total_size);
+        $this->assertNull($result->masking_method_applied);
     }
 
     /**
-     * Test update snapshot updates existing snapshot.
+     * Test update snapshot updates existing snapshot with new fields.
      */
     public function test_update_snapshot_updates_existing_snapshot(): void
     {
         $snapshot = DatasetSnapshot::factory()->create([
             'version_tag' => 'v1.0',
             'row_count' => 1000,
+            'status' => Status::ACTIVE->value,
         ]);
 
         $updateData = [
             'version_tag' => 'v1.1',
             'row_count' => 1500,
+            'file_count' => 150,
+            'total_size' => 2097152,
             'quality_checksums' => hash('sha256', 'updated'),
+            'compression' => Compression::SNAPPY->value,
+            'masking_method_applied' => MaskingMethod::HASHING->value,
+            'status' => Status::DEPRECATED->value,
         ];
 
         $result = $this->repository->updateSnapshot($snapshot, $updateData);
@@ -271,7 +309,10 @@ class DatasetSnapshotRepositoryTest extends TestCase
         $snapshot->refresh();
         $this->assertEquals('v1.1', $snapshot->version_tag);
         $this->assertEquals(1500, $snapshot->row_count);
+        $this->assertEquals(150, $snapshot->file_count);
         $this->assertEquals($updateData['quality_checksums'], $snapshot->quality_checksums);
+        $this->assertEquals(Compression::SNAPPY->value, $snapshot->compression);
+        $this->assertEquals(Status::DEPRECATED->value, $snapshot->status);
     }
 
     /**
@@ -314,12 +355,14 @@ class DatasetSnapshotRepositoryTest extends TestCase
         $snapshot = DatasetSnapshot::factory()->for($dataset)->create([
             'time_range_start' => null,
             'time_range_end' => null,
+            'expiration_date' => null,
         ]);
 
         $result = $this->repository->getSnapshotById($snapshot->id);
 
         $this->assertNull($result->time_range_start);
         $this->assertNull($result->time_range_end);
+        $this->assertNull($result->expiration_date);
     }
 
     /**
@@ -331,34 +374,232 @@ class DatasetSnapshotRepositoryTest extends TestCase
 
         $snapshot = DatasetSnapshot::factory()->for($dataset)->create([
             'row_count' => null,
+            'file_count' => null,
             'pii_element_count' => null,
-            'special_category_element_count' => null,
+            'total_size' => null,
+            'consent_coverage_at_creation' => null,
         ]);
 
         $result = $this->repository->getSnapshotById($snapshot->id);
 
         $this->assertNull($result->row_count);
+        $this->assertNull($result->file_count);
         $this->assertNull($result->pii_element_count);
-        $this->assertNull($result->special_category_element_count);
+        $this->assertNull($result->total_size);
+        $this->assertNull($result->consent_coverage_at_creation);
     }
 
     /**
-     * Test repository handles nullable text fields.
+     * Test repository handles nullable text and enum fields.
      */
-    public function test_repository_handles_nullable_text_fields(): void
+    public function test_repository_handles_nullable_text_and_enum_fields(): void
     {
         $dataset = Dataset::factory()->create();
 
         $snapshot = DatasetSnapshot::factory()->for($dataset)->create([
             'quality_checksums' => null,
-            'masking_anonymization_method' => null,
-            'privacy_transform_evidence_ref' => null,
+            'masking_method_applied' => null,
+            'compression' => null,
+            'storage_tier' => null,
+            'approved_by' => null,
+            'description' => null,
+            'size_unit' => null,
+            'supersedes_snapshot_id' => null,
         ]);
 
         $result = $this->repository->getSnapshotById($snapshot->id);
 
         $this->assertNull($result->quality_checksums);
-        $this->assertNull($result->masking_anonymization_method);
-        $this->assertNull($result->privacy_transform_evidence_ref);
+        $this->assertNull($result->masking_method_applied);
+        $this->assertNull($result->compression);
+        $this->assertNull($result->storage_tier);
+        $this->assertNull($result->approved_by);
+        $this->assertNull($result->description);
+        $this->assertNull($result->size_unit);
+        $this->assertNull($result->supersedes_snapshot_id);
+    }
+
+    /**
+     * Test repository handles all file format enums.
+     */
+    public function test_repository_handles_all_file_format_enums(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        foreach (FileFormat::cases() as $format) {
+            $snapshot = DatasetSnapshot::factory()->for($dataset)->create([
+                'file_format' => $format->value,
+            ]);
+
+            $result = $this->repository->getSnapshotById($snapshot->id);
+            $this->assertEquals($format->value, $result->file_format);
+        }
+    }
+
+    /**
+     * Test repository handles all encryption status enums.
+     */
+    public function test_repository_handles_all_encryption_status_enums(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        foreach (EncryptionStatus::cases() as $status) {
+            $snapshot = DatasetSnapshot::factory()->for($dataset)->create([
+                'encryption_status' => $status->value,
+            ]);
+
+            $result = $this->repository->getSnapshotById($snapshot->id);
+            $this->assertEquals($status->value, $result->encryption_status);
+        }
+    }
+
+    /**
+     * Test repository handles all residency zone enums.
+     */
+    public function test_repository_handles_all_residency_zone_enums(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        foreach (ResidencyZone::cases() as $zone) {
+            $snapshot = DatasetSnapshot::factory()->for($dataset)->create([
+                'residency_zone' => $zone->value,
+            ]);
+
+            $result = $this->repository->getSnapshotById($snapshot->id);
+            $this->assertEquals($zone->value, $result->residency_zone);
+        }
+    }
+
+    /**
+     * Test repository handles all status enums.
+     */
+    public function test_repository_handles_all_status_enums(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        foreach (Status::cases() as $status) {
+            $snapshot = DatasetSnapshot::factory()->for($dataset)->create([
+                'status' => $status->value,
+            ]);
+
+            $result = $this->repository->getSnapshotById($snapshot->id);
+            $this->assertEquals($status->value, $result->status);
+        }
+    }
+
+    /**
+     * Test repository handles compression enums.
+     */
+    public function test_repository_handles_compression_enums(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        foreach (Compression::cases() as $compression) {
+            $snapshot = DatasetSnapshot::factory()->for($dataset)->create([
+                'compression' => $compression->value,
+            ]);
+
+            $result = $this->repository->getSnapshotById($snapshot->id);
+            $this->assertEquals($compression->value, $result->compression);
+        }
+    }
+
+    /**
+     * Test repository handles storage tier enums.
+     */
+    public function test_repository_handles_storage_tier_enums(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        foreach (StorageTier::cases() as $tier) {
+            $snapshot = DatasetSnapshot::factory()->for($dataset)->create([
+                'storage_tier' => $tier->value,
+            ]);
+
+            $result = $this->repository->getSnapshotById($snapshot->id);
+            $this->assertEquals($tier->value, $result->storage_tier);
+        }
+    }
+
+    /**
+     * Test repository handles masking method enums.
+     */
+    public function test_repository_handles_masking_method_enums(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        foreach (MaskingMethod::cases() as $method) {
+            $snapshot = DatasetSnapshot::factory()->for($dataset)->create([
+                'masking_method_applied' => $method->value,
+            ]);
+
+            $result = $this->repository->getSnapshotById($snapshot->id);
+            $this->assertEquals($method->value, $result->masking_method_applied);
+        }
+    }
+
+    /**
+     * Test repository handles approved by enums.
+     */
+    public function test_repository_handles_approved_by_enums(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        foreach (ApprovedBy::cases() as $approver) {
+            $snapshot = DatasetSnapshot::factory()->for($dataset)->create([
+                'approved_by' => $approver->value,
+            ]);
+
+            $result = $this->repository->getSnapshotById($snapshot->id);
+            $this->assertEquals($approver->value, $result->approved_by);
+        }
+    }
+
+    /**
+     * Test repository handles boolean fields.
+     */
+    public function test_repository_handles_boolean_fields(): void
+    {
+        $dataset = Dataset::factory()->create();
+
+        $snapshotTrue = DatasetSnapshot::factory()->for($dataset)->create([
+            'created_by_system' => true,
+        ]);
+
+        $snapshotFalse = DatasetSnapshot::factory()->for($dataset)->create([
+            'created_by_system' => false,
+        ]);
+
+        $resultTrue = $this->repository->getSnapshotById($snapshotTrue->id);
+        $resultFalse = $this->repository->getSnapshotById($snapshotFalse->id);
+
+        $this->assertTrue($resultTrue->created_by_system);
+        $this->assertFalse($resultFalse->created_by_system);
+    }
+
+    /**
+     * Test repository handles snapshot with superseded relationship.
+     */
+    public function test_repository_handles_snapshot_superseding(): void
+    {
+        $dataset = Dataset::factory()->create();
+        $previousSnapshot = DatasetSnapshot::factory()->for($dataset)->create([
+            'version_tag' => 'v1.0',
+            'status' => Status::ACTIVE->value,
+        ]);
+
+        $newSnapshot = DatasetSnapshot::factory()->for($dataset)->create([
+            'version_tag' => 'v2.0',
+            'supersedes_snapshot_id' => $previousSnapshot->id,
+            'status' => Status::ACTIVE->value,
+        ]);
+
+        $result = $this->repository->getSnapshotById($newSnapshot->id);
+
+        $this->assertEquals($previousSnapshot->id, $result->supersedes_snapshot_id);
+        $this->assertDatabaseHas('dataset_snapshots', [
+            'id' => $newSnapshot->id,
+            'supersedes_snapshot_id' => $previousSnapshot->id,
+        ]);
     }
 }


### PR DESCRIPTION
- Added new fields to DatasetSnapshot model: supersedes_snapshot_id, description, file_count, total_size, size_unit, file_format, consent_coverage_at_creation, storage_tier, compression, encryption_status, masking_method_applied, created_by_system, approved_by, expiration_date, and status.
- Updated DatasetSnapshotResource to include new fields in the API response.
- Modified DatasetSnapshotFactory to generate data for new fields.
- Created a migration to modify the dataset_snapshots table structure.
- Updated DatasetSnapshotControllerTest to validate new fields and their constraints.
- Enhanced DatasetSnapshotRepositoryTest to ensure proper handling of new fields and relationships.