### PR TITLE
feat: Introduce AlertSeverity enum and update IncidentAlert model

### DIFF
--- a/app/Enums/IncidentAlert/AlertSeverity.php
+++ b/app/Enums/IncidentAlert/AlertSeverity.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums\IncidentAlert;
+
+enum AlertSeverity: string
+{
+    case LOW = 'low';
+    case MEDIUM = 'medium';
+    case HIGH = 'high';
+    case CRITICAL = 'critical';
+}

--- a/app/Enums/IncidentAlert/AlertSourceType.php
+++ b/app/Enums/IncidentAlert/AlertSourceType.php
@@ -4,10 +4,10 @@ namespace App\Enums\IncidentAlert;
 
 enum AlertSourceType: string
 {
-    case KRI = 'kri';
     case MONITORING_RULE = 'monitoring_rule';
-    case HUMAN_REPORT = 'human_report';
-    case VENDOR_NOTICE = 'vendor_notice';
-    case SECURITY_TOOL = 'security_tool';
-    case OTHER = 'other';
+    case KRI_THRESHOLD = 'kri_threshold';
+    case MANUAL_REPORT = 'manual_report';
+    case AUTOMATED_SCAN = 'automated_scan';
+    case USER_COMPLAINT = 'user_complaint';
+    case EXTERNAL_REPORT = 'external_report';
 }

--- a/app/Http/Controllers/IncidentAlertController.php
+++ b/app/Http/Controllers/IncidentAlertController.php
@@ -2,14 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\IncidentAlert;
+use Illuminate\Http\JsonResponse;
+use App\Http\Resources\IncidentAlertResource;
+use App\Repositories\IncidentAlertRepository;
 use App\Http\Requests\IncidentAlert\ListIncidentAlertRequest;
 use App\Http\Requests\IncidentAlert\StoreIncidentAlertRequest;
 use App\Http\Requests\IncidentAlert\UpdateIncidentAlertRequest;
-use App\Http\Resources\IncidentAlertResource;
-use App\Models\IncidentAlert;
-use App\Repositories\IncidentAlertRepository;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 
 class IncidentAlertController extends Controller
 {
@@ -55,6 +54,7 @@ class IncidentAlertController extends Controller
     public function show(IncidentAlert $incidentAlert): JsonResponse
     {
         $incidentAlert = $this->incidentAlertRepository->getIncidentAlertById($incidentAlert);
+
         return response()->json([
             'error' => false,
             'message' => 'Incident alert retrieved successfully',

--- a/app/Http/Requests/IncidentAlert/StoreIncidentAlertRequest.php
+++ b/app/Http/Requests/IncidentAlert/StoreIncidentAlertRequest.php
@@ -2,9 +2,10 @@
 
 namespace App\Http\Requests\IncidentAlert;
 
-use App\Enums\IncidentAlert\AlertSourceType;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use App\Enums\IncidentAlert\AlertSeverity;
+use Illuminate\Foundation\Http\FormRequest;
+use App\Enums\IncidentAlert\AlertSourceType;
 
 class StoreIncidentAlertRequest extends FormRequest
 {
@@ -25,13 +26,15 @@ class StoreIncidentAlertRequest extends FormRequest
     {
         return [
             'ai_incident_id' => ['required', 'integer', 'exists:ai_incidents,id'],
-            'source_type' => ['required', Rule::in(array_map(fn($c) => $c->value, AlertSourceType::cases()))],
+            'source_type' => ['required', Rule::enum(AlertSourceType::class)],
+            'data_source_id' => ['nullable', 'integer', 'exists:data_sources,id'],
+            'alert_sensitivity' => ['required', Rule::enum(AlertSeverity::class)],
             'source_ref' => ['nullable', 'string', 'max:255'],
-            'rule_version' => ['nullable', 'string', 'max:255'],
-            'context' => ['nullable', 'string'],
+            'context' => ['required', 'string'],
             'first_seen_at' => ['required', 'date'],
             'last_seen_at' => ['nullable', 'date', 'after_or_equal:first_seen_at'],
             'evidence_link' => ['nullable', 'url', 'max:2048'],
+            'auto_promote_incident' => ['nullable', 'boolean'],
         ];
     }
 

--- a/app/Http/Requests/IncidentAlert/UpdateIncidentAlertRequest.php
+++ b/app/Http/Requests/IncidentAlert/UpdateIncidentAlertRequest.php
@@ -2,9 +2,10 @@
 
 namespace App\Http\Requests\IncidentAlert;
 
-use App\Enums\IncidentAlert\AlertSourceType;
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use App\Enums\IncidentAlert\AlertSeverity;
+use Illuminate\Foundation\Http\FormRequest;
+use App\Enums\IncidentAlert\AlertSourceType;
 
 class UpdateIncidentAlertRequest extends FormRequest
 {
@@ -25,13 +26,15 @@ class UpdateIncidentAlertRequest extends FormRequest
     {
         return [
             'ai_incident_id' => ['sometimes', 'integer', 'exists:ai_incidents,id'],
-            'source_type' => ['sometimes', Rule::in(array_map(fn($c) => $c->value, AlertSourceType::cases()))],
-            'source_ref' => ['nullable', 'string', 'max:255'],
-            'rule_version' => ['nullable', 'string', 'max:255'],
-            'context' => ['nullable', 'string'],
+            'source_type' => ['sometimes', Rule::enum(AlertSourceType::class)],
+            'data_source_id' => ['sometimes', 'nullable', 'integer', 'exists:data_sources,id'],
+            'alert_sensitivity' => ['sometimes', Rule::enum(AlertSeverity::class)],
+            'source_ref' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'context' => ['sometimes', 'string'],
             'first_seen_at' => ['sometimes', 'date'],
-            'last_seen_at' => ['nullable', 'date', 'after_or_equal:first_seen_at'],
-            'evidence_link' => ['nullable', 'url', 'max:2048'],
+            'last_seen_at' => ['sometimes', 'nullable', 'date', 'after_or_equal:first_seen_at'],
+            'evidence_link' => ['sometimes', 'nullable', 'url', 'max:2048'],
+            'auto_promote_incident' => ['sometimes', 'nullable', 'boolean'],
         ];
     }
 

--- a/app/Http/Resources/IncidentAlertResource.php
+++ b/app/Http/Resources/IncidentAlertResource.php
@@ -20,13 +20,17 @@ class IncidentAlertResource extends JsonResource
     {
         return [
             'id' => $this->id,
+            'display_id' => $this->display_id,
+            'organization_id' => $this->organization_id,
             'ai_incident_id' => $this->ai_incident_id,
             'source_type' => $this->source_type,
+            'data_source_id' => $this->data_source_id,
             'source_ref' => $this->source_ref,
-            'rule_version' => $this->rule_version,
+            'alert_sensitivity' => $this->alert_sensitivity,
             'context' => $this->context,
             'first_seen_at' => $this->first_seen_at ? Carbon::parse($this->first_seen_at)->toIso8601String() : null,
             'last_seen_at' => $this->last_seen_at ? Carbon::parse($this->last_seen_at)->toIso8601String() : null,
+            'auto_promote_incident' => $this->auto_promote_incident,
             'evidence_link' => $this->evidence_link,
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),

--- a/app/Models/IncidentAlert.php
+++ b/app/Models/IncidentAlert.php
@@ -15,11 +15,13 @@ class IncidentAlert extends Model
         'organization_id',
         'ai_incident_id',
         'source_type',
+        'data_source_id',
         'source_ref',
-        'rule_version',
+        'alert_sensitivity',
         'context',
         'first_seen_at',
         'last_seen_at',
+        'auto_promote_incident',
         'evidence_link',
     ];
 
@@ -28,6 +30,7 @@ class IncidentAlert extends Model
         return [
             'first_seen_at' => 'datetime',
             'last_seen_at' => 'datetime',
+            'auto_promote_incident' => 'boolean',
         ];
     }
 

--- a/database/factories/IncidentAlertFactory.php
+++ b/database/factories/IncidentAlertFactory.php
@@ -3,6 +3,8 @@
 namespace Database\Factories;
 
 use App\Models\AiIncident;
+use App\Models\DataSource;
+use App\Enums\IncidentAlert\AlertSeverity;
 use App\Enums\IncidentAlert\AlertSourceType;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -24,24 +26,27 @@ class IncidentAlertFactory extends Factory
         return [
             'organization_id' => \App\Models\Organization::factory(),
             'ai_incident_id' => AiIncident::factory(),
-            'source_type' => $this->faker->randomElement(array_map(fn($c) => $c->value, AlertSourceType::cases())),
+            'source_type' => $this->faker->randomElement(array_map(fn ($c) => $c->value, AlertSourceType::cases())),
+            'data_source_id' => DataSource::factory(),
             'source_ref' => $this->faker->optional(0.6)->regexify('[A-Z]{3}-[0-9]{3,6}'),
-            'rule_version' => $this->faker->optional(0.5)->regexify('v[0-9]\.[0-9]\.[0-9]'),
-            'context' => $this->faker->optional(0.7)->sentence(20),
+            'alert_sensitivity' => $this->faker->randomElement(array_map(fn ($c) => $c->value, AlertSeverity::cases())),
+            'context' => $this->faker->sentence(20),
             'first_seen_at' => $firstSeenAt,
             'last_seen_at' => $lastSeenAt,
+            'auto_promote_incident' => $this->faker->boolean(20),
             'evidence_link' => $this->faker->optional(0.6)->url(),
         ];
     }
 
     /**
-     * Indicate that the alert is from a KRI source.
+     * Indicate that the alert is from a KRI threshold.
      */
-    public function fromKri(): static
+    public function fromKriThreshold(): static
     {
-        return $this->state(fn(array $attributes) => [
-            'source_type' => AlertSourceType::KRI->value,
-            'source_ref' => 'KRI-' . $this->faker->numberBetween(100, 999),
+        return $this->state(fn (array $attributes) => [
+            'source_type' => AlertSourceType::KRI_THRESHOLD->value,
+            'source_ref' => 'KRI-'.$this->faker->numberBetween(100, 999),
+            'alert_sensitivity' => AlertSeverity::HIGH->value,
         ]);
     }
 
@@ -50,21 +55,58 @@ class IncidentAlertFactory extends Factory
      */
     public function fromMonitoringRule(): static
     {
-        return $this->state(fn(array $attributes) => [
+        return $this->state(fn (array $attributes) => [
             'source_type' => AlertSourceType::MONITORING_RULE->value,
-            'source_ref' => 'RULE-' . $this->faker->numberBetween(1000, 9999),
-            'rule_version' => 'v' . $this->faker->numberBetween(1, 5) . '.' . $this->faker->numberBetween(0, 9) . '.0',
+            'source_ref' => 'RULE-'.$this->faker->numberBetween(1000, 9999),
+            'alert_sensitivity' => AlertSeverity::MEDIUM->value,
         ]);
     }
 
     /**
-     * Indicate that the alert is from a human report.
+     * Indicate that the alert is from a manual report.
      */
-    public function fromHumanReport(): static
+    public function fromManualReport(): static
     {
-        return $this->state(fn(array $attributes) => [
-            'source_type' => AlertSourceType::HUMAN_REPORT->value,
-            'source_ref' => 'TICKET-' . $this->faker->numberBetween(10000, 99999),
+        return $this->state(fn (array $attributes) => [
+            'source_type' => AlertSourceType::MANUAL_REPORT->value,
+            'source_ref' => 'TICKET-'.$this->faker->numberBetween(10000, 99999),
+            'alert_sensitivity' => AlertSeverity::MEDIUM->value,
+        ]);
+    }
+
+    /**
+     * Indicate that the alert is from an automated scan.
+     */
+    public function fromAutomatedScan(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'source_type' => AlertSourceType::AUTOMATED_SCAN->value,
+            'source_ref' => 'SCAN-'.$this->faker->numberBetween(10000, 99999),
+            'alert_sensitivity' => AlertSeverity::MEDIUM->value,
+        ]);
+    }
+
+    /**
+     * Indicate that the alert is from a user complaint.
+     */
+    public function fromUserComplaint(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'source_type' => AlertSourceType::USER_COMPLAINT->value,
+            'source_ref' => 'COMPLAINT-'.$this->faker->numberBetween(1000, 9999),
+            'alert_sensitivity' => AlertSeverity::LOW->value,
+        ]);
+    }
+
+    /**
+     * Indicate that the alert is from an external report.
+     */
+    public function fromExternalReport(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'source_type' => AlertSourceType::EXTERNAL_REPORT->value,
+            'source_ref' => 'EXT-'.$this->faker->numberBetween(10000, 99999),
+            'alert_sensitivity' => AlertSeverity::HIGH->value,
         ]);
     }
 
@@ -75,9 +117,29 @@ class IncidentAlertFactory extends Factory
     {
         $firstSeenAt = now()->subHours($this->faker->numberBetween(1, 6));
 
-        return $this->state(fn(array $attributes) => [
+        return $this->state(fn (array $attributes) => [
             'first_seen_at' => $firstSeenAt,
             'last_seen_at' => now()->subMinutes($this->faker->numberBetween(5, 60)),
+        ]);
+    }
+
+    /**
+     * Indicate that the alert should auto-promote to incident.
+     */
+    public function autoPromote(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'auto_promote_incident' => true,
+        ]);
+    }
+
+    /**
+     * Indicate that the alert is critical.
+     */
+    public function critical(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'alert_sensitivity' => AlertSeverity::CRITICAL->value,
         ]);
     }
 }

--- a/database/migrations/2025_12_31_071106_modify_incident_alerts_table.php
+++ b/database/migrations/2025_12_31_071106_modify_incident_alerts_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\DataSource;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('incident_alerts', function (Blueprint $table) {
+            if (Schema::hasColumn('incident_alerts', 'rule_version')) {
+                $table->dropColumn('rule_version');
+            }
+            $table->foreignIdFor(DataSource::class)
+                ->nullable()
+                ->after('source_type')
+                ->constrained()
+                ->nullOnDelete();
+
+            $table->string('alert_sensitivity')->nullable()->after('source_ref');
+            $table->boolean('auto_promote_incident')->default(false)->after('last_seen_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('incident_alerts', function (Blueprint $table) {
+            $table->string('rule_version')->nullable();
+
+            if (Schema::hasColumn('incident_alerts', 'data_source_id')) {
+                $table->dropForeign(['data_source_id']);
+                $table->dropColumn('data_source_id');
+            }
+
+            if (Schema::hasColumn('incident_alerts', 'alert_sensitivity')) {
+                $table->dropColumn('alert_sensitivity');
+            }
+
+            if (Schema::hasColumn('incident_alerts', 'auto_promote_incident')) {
+                $table->dropColumn('auto_promote_incident');
+            }
+        });
+    }
+};

--- a/tests/Feature/IncidentAlertControllerTest.php
+++ b/tests/Feature/IncidentAlertControllerTest.php
@@ -2,18 +2,22 @@
 
 namespace Tests\Feature;
 
-use App\Models\AiIncident;
-use App\Models\IncidentAlert;
-use App\Models\Organization;
-use App\Models\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
+use App\Models\User;
+use App\Models\AiIncident;
+use App\Models\DataSource;
+use App\Models\Organization;
+use App\Models\IncidentAlert;
+use App\Enums\IncidentAlert\AlertSeverity;
+use App\Enums\IncidentAlert\AlertSourceType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class IncidentAlertControllerTest extends TestCase
 {
     use RefreshDatabase;
 
     protected User $user;
+
     protected Organization $organization;
 
     protected function setUp(): void
@@ -45,13 +49,17 @@ class IncidentAlertControllerTest extends TestCase
                     'data' => [
                         '*' => [
                             'id',
+                            'display_id',
+                            'organization_id',
                             'ai_incident_id',
                             'source_type',
+                            'data_source_id',
                             'source_ref',
-                            'rule_version',
+                            'alert_sensitivity',
                             'context',
                             'first_seen_at',
                             'last_seen_at',
+                            'auto_promote_incident',
                             'evidence_link',
                             'created_at',
                             'updated_at',
@@ -68,7 +76,9 @@ class IncidentAlertControllerTest extends TestCase
         $incident = AiIncident::factory()->create();
         $data = [
             'ai_incident_id' => $incident->id,
-            'source_type' => 'kri',
+            'source_type' => AlertSourceType::KRI_THRESHOLD->value,
+            'alert_sensitivity' => AlertSeverity::MEDIUM->value,
+            'context' => 'Test context',
             'first_seen_at' => now()->subHour()->toDateTimeString(),
         ];
 
@@ -81,28 +91,32 @@ class IncidentAlertControllerTest extends TestCase
                 'message' => 'Incident alert created successfully',
             ])
             ->assertJsonPath('data.ai_incident_id', $incident->id)
-            ->assertJsonPath('data.source_type', 'kri');
+            ->assertJsonPath('data.source_type', AlertSourceType::KRI_THRESHOLD->value)
+            ->assertJsonPath('data.alert_sensitivity', AlertSeverity::MEDIUM->value);
 
         $this->assertDatabaseHas('incident_alerts', [
             'ai_incident_id' => $incident->id,
-            'source_type' => 'kri',
+            'source_type' => AlertSourceType::KRI_THRESHOLD->value,
         ]);
     }
 
     public function test_store_creates_incident_alert_with_all_fields(): void
     {
+        $dataSource = DataSource::factory()->create();
         $incident = AiIncident::factory()->create();
         $firstSeenAt = now()->subHours(2);
         $lastSeenAt = now()->subHour();
 
         $data = [
             'ai_incident_id' => $incident->id,
-            'source_type' => 'monitoring_rule',
+            'source_type' => AlertSourceType::MONITORING_RULE->value,
+            'data_source_id' => $dataSource->id,
             'source_ref' => 'RULE-1234',
-            'rule_version' => 'v2.1.0',
+            'alert_sensitivity' => AlertSeverity::HIGH->value,
             'context' => 'Test context for monitoring rule alert',
             'first_seen_at' => $firstSeenAt->toDateTimeString(),
             'last_seen_at' => $lastSeenAt->toDateTimeString(),
+            'auto_promote_incident' => true,
             'evidence_link' => 'https://example.com/evidence/123',
         ];
 
@@ -110,16 +124,18 @@ class IncidentAlertControllerTest extends TestCase
             ->postJson('/api/incident-alerts', $data);
 
         $response->assertStatus(201)
-            ->assertJsonPath('data.source_type', 'monitoring_rule')
+            ->assertJsonPath('data.source_type', AlertSourceType::MONITORING_RULE->value)
+            ->assertJsonPath('data.data_source_id', $dataSource->id)
             ->assertJsonPath('data.source_ref', 'RULE-1234')
-            ->assertJsonPath('data.rule_version', 'v2.1.0')
+            ->assertJsonPath('data.alert_sensitivity', AlertSeverity::HIGH->value)
             ->assertJsonPath('data.context', 'Test context for monitoring rule alert')
+            ->assertJsonPath('data.auto_promote_incident', true)
             ->assertJsonPath('data.evidence_link', 'https://example.com/evidence/123');
 
         $this->assertDatabaseHas('incident_alerts', [
             'ai_incident_id' => $incident->id,
             'source_ref' => 'RULE-1234',
-            'rule_version' => 'v2.1.0',
+            'data_source_id' => $dataSource->id,
         ]);
     }
 
@@ -157,6 +173,8 @@ class IncidentAlertControllerTest extends TestCase
         $incident = AiIncident::factory()->create();
         $data = [
             'ai_incident_id' => $incident->id,
+            'alert_sensitivity' => AlertSeverity::MEDIUM->value,
+            'context' => 'Test context',
             'first_seen_at' => now()->toDateTimeString(),
         ];
 
@@ -173,6 +191,8 @@ class IncidentAlertControllerTest extends TestCase
         $data = [
             'ai_incident_id' => $incident->id,
             'source_type' => 'invalid_source',
+            'alert_sensitivity' => AlertSeverity::MEDIUM->value,
+            'context' => 'Test context',
             'first_seen_at' => now()->toDateTimeString(),
         ];
 
@@ -188,7 +208,9 @@ class IncidentAlertControllerTest extends TestCase
         $incident = AiIncident::factory()->create();
         $data = [
             'ai_incident_id' => $incident->id,
-            'source_type' => 'kri',
+            'source_type' => AlertSourceType::KRI_THRESHOLD->value,
+            'alert_sensitivity' => AlertSeverity::MEDIUM->value,
+            'context' => 'Test context',
         ];
 
         $response = $this->actingAs($this->user, 'supabase')
@@ -203,7 +225,9 @@ class IncidentAlertControllerTest extends TestCase
         $incident = AiIncident::factory()->create();
         $data = [
             'ai_incident_id' => $incident->id,
-            'source_type' => 'kri',
+            'source_type' => AlertSourceType::KRI_THRESHOLD->value,
+            'alert_sensitivity' => AlertSeverity::MEDIUM->value,
+            'context' => 'Test context',
             'first_seen_at' => now()->toDateTimeString(),
             'last_seen_at' => now()->subHour()->toDateTimeString(),
         ];
@@ -220,7 +244,9 @@ class IncidentAlertControllerTest extends TestCase
         $incident = AiIncident::factory()->create();
         $data = [
             'ai_incident_id' => $incident->id,
-            'source_type' => 'kri',
+            'source_type' => AlertSourceType::KRI_THRESHOLD->value,
+            'alert_sensitivity' => AlertSeverity::MEDIUM->value,
+            'context' => 'Test context',
             'first_seen_at' => now()->toDateTimeString(),
             'evidence_link' => 'not-a-valid-url',
         ];
@@ -235,12 +261,21 @@ class IncidentAlertControllerTest extends TestCase
     public function test_store_accepts_all_valid_source_types(): void
     {
         $incident = AiIncident::factory()->create();
-        $sourceTypes = ['kri', 'monitoring_rule', 'human_report', 'vendor_notice', 'security_tool', 'other'];
+        $sourceTypes = [
+            AlertSourceType::MONITORING_RULE->value,
+            AlertSourceType::KRI_THRESHOLD->value,
+            AlertSourceType::MANUAL_REPORT->value,
+            AlertSourceType::AUTOMATED_SCAN->value,
+            AlertSourceType::USER_COMPLAINT->value,
+            AlertSourceType::EXTERNAL_REPORT->value,
+        ];
 
         foreach ($sourceTypes as $sourceType) {
             $data = [
                 'ai_incident_id' => $incident->id,
                 'source_type' => $sourceType,
+                'alert_sensitivity' => AlertSeverity::MEDIUM->value,
+                'context' => 'Test context',
                 'first_seen_at' => now()->toDateTimeString(),
             ];
 
@@ -262,7 +297,7 @@ class IncidentAlertControllerTest extends TestCase
     public function test_show_returns_incident_alert(): void
     {
         $alert = IncidentAlert::factory()->create([
-            'source_type' => 'kri',
+            'source_type' => AlertSourceType::KRI_THRESHOLD->value,
             'source_ref' => 'KRI-123',
         ]);
 
@@ -275,7 +310,7 @@ class IncidentAlertControllerTest extends TestCase
                 'message' => 'Incident alert retrieved successfully',
             ])
             ->assertJsonPath('data.id', $alert->id)
-            ->assertJsonPath('data.source_type', 'kri')
+            ->assertJsonPath('data.source_type', AlertSourceType::KRI_THRESHOLD->value)
             ->assertJsonPath('data.source_ref', 'KRI-123');
     }
 
@@ -299,12 +334,12 @@ class IncidentAlertControllerTest extends TestCase
     public function test_update_modifies_incident_alert(): void
     {
         $alert = IncidentAlert::factory()->create([
-            'source_type' => 'kri',
+            'source_type' => AlertSourceType::KRI_THRESHOLD->value,
             'source_ref' => 'OLD-REF',
         ]);
 
         $updateData = [
-            'source_type' => 'monitoring_rule',
+            'source_type' => AlertSourceType::MONITORING_RULE->value,
             'source_ref' => 'NEW-REF',
         ];
 
@@ -316,12 +351,12 @@ class IncidentAlertControllerTest extends TestCase
                 'error' => false,
                 'message' => 'Incident alert updated successfully',
             ])
-            ->assertJsonPath('data.source_type', 'monitoring_rule')
+            ->assertJsonPath('data.source_type', AlertSourceType::MONITORING_RULE->value)
             ->assertJsonPath('data.source_ref', 'NEW-REF');
 
         $this->assertDatabaseHas('incident_alerts', [
             'id' => $alert->id,
-            'source_type' => 'monitoring_rule',
+            'source_type' => AlertSourceType::MONITORING_RULE->value,
             'source_ref' => 'NEW-REF',
         ]);
     }
@@ -329,20 +364,20 @@ class IncidentAlertControllerTest extends TestCase
     public function test_update_supports_partial_updates(): void
     {
         $alert = IncidentAlert::factory()->create([
-            'source_type' => 'kri',
+            'source_type' => AlertSourceType::KRI_THRESHOLD->value,
             'source_ref' => 'KRI-123',
-            'rule_version' => 'v1.0.0',
+            'alert_sensitivity' => AlertSeverity::MEDIUM->value,
         ]);
 
-        $updateData = ['rule_version' => 'v2.0.0'];
+        $updateData = ['alert_sensitivity' => AlertSeverity::HIGH->value];
 
         $response = $this->actingAs($this->user, 'supabase')
             ->postJson("/api/incident-alerts/{$alert->id}", $updateData);
 
         $response->assertStatus(200)
-            ->assertJsonPath('data.source_type', 'kri')
+            ->assertJsonPath('data.source_type', AlertSourceType::KRI_THRESHOLD->value)
             ->assertJsonPath('data.source_ref', 'KRI-123')
-            ->assertJsonPath('data.rule_version', 'v2.0.0');
+            ->assertJsonPath('data.alert_sensitivity', AlertSeverity::HIGH->value);
     }
 
     public function test_update_validates_source_type_enum(): void
@@ -356,6 +391,19 @@ class IncidentAlertControllerTest extends TestCase
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['source_type']);
+    }
+
+    public function test_update_validates_alert_sensitivity_enum(): void
+    {
+        $alert = IncidentAlert::factory()->create();
+
+        $updateData = ['alert_sensitivity' => 'invalid_severity'];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson("/api/incident-alerts/{$alert->id}", $updateData);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['alert_sensitivity']);
     }
 
     public function test_update_validates_evidence_link_is_url(): void
@@ -413,5 +461,74 @@ class IncidentAlertControllerTest extends TestCase
         $response = $this->deleteJson("/api/incident-alerts/{$alert->id}");
 
         $response->assertStatus(401);
+    }
+
+    public function test_store_accepts_all_valid_alert_severities(): void
+    {
+        $incident = AiIncident::factory()->create();
+        $severities = [
+            AlertSeverity::LOW->value,
+            AlertSeverity::MEDIUM->value,
+            AlertSeverity::HIGH->value,
+            AlertSeverity::CRITICAL->value,
+        ];
+
+        foreach ($severities as $severity) {
+            $data = [
+                'ai_incident_id' => $incident->id,
+                'source_type' => AlertSourceType::MONITORING_RULE->value,
+                'alert_sensitivity' => $severity,
+                'context' => 'Test context',
+                'first_seen_at' => now()->toDateTimeString(),
+            ];
+
+            $response = $this->actingAs($this->user, 'supabase')
+                ->postJson('/api/incident-alerts', $data);
+
+            $response->assertStatus(201)
+                ->assertJsonPath('data.alert_sensitivity', $severity);
+        }
+    }
+
+    public function test_store_with_data_source_id(): void
+    {
+        // Create multiple DataSources to support potential Dataset factory calls
+        DataSource::factory()->count(3)->create();
+
+        $dataSource = DataSource::factory()->create();
+        $incident = AiIncident::factory()->create();
+        $data = [
+            'ai_incident_id' => $incident->id,
+            'source_type' => AlertSourceType::MONITORING_RULE->value,
+            'data_source_id' => $dataSource->id,
+            'alert_sensitivity' => AlertSeverity::MEDIUM->value,
+            'context' => 'Test context',
+            'first_seen_at' => now()->toDateTimeString(),
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/incident-alerts', $data);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.data_source_id', $dataSource->id);
+    }
+
+    public function test_store_with_auto_promote_incident(): void
+    {
+        $incident = AiIncident::factory()->create();
+        $data = [
+            'ai_incident_id' => $incident->id,
+            'source_type' => AlertSourceType::EXTERNAL_REPORT->value,
+            'auto_promote_incident' => true,
+            'alert_sensitivity' => AlertSeverity::CRITICAL->value,
+            'context' => 'Critical external report',
+            'first_seen_at' => now()->toDateTimeString(),
+        ];
+
+        $response = $this->actingAs($this->user, 'supabase')
+            ->postJson('/api/incident-alerts', $data);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.auto_promote_incident', true);
     }
 }

--- a/tests/Feature/Repositories/IncidentAlertRepositoryTest.php
+++ b/tests/Feature/Repositories/IncidentAlertRepositoryTest.php
@@ -2,18 +2,21 @@
 
 namespace Tests\Feature\Repositories;
 
+use Tests\TestCase;
 use App\Models\AiIncident;
-use App\Models\IncidentAlert;
 use App\Models\Organization;
+use App\Models\IncidentAlert;
+use App\Enums\IncidentAlert\AlertSeverity;
+use App\Enums\IncidentAlert\AlertSourceType;
 use App\Repositories\IncidentAlertRepository;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Tests\TestCase;
 
 class IncidentAlertRepositoryTest extends TestCase
 {
     use RefreshDatabase;
 
     protected IncidentAlertRepository $repository;
+
     protected Organization $organization;
 
     protected function setUp(): void
@@ -25,7 +28,7 @@ class IncidentAlertRepositoryTest extends TestCase
 
     public function test_get_paginated_incident_alerts_returns_paginated_results(): void
     {
-        IncidentAlert::factory()->count(25)->create();
+        IncidentAlert::factory()->count(25)->create(['organization_id' => $this->organization->id]);
 
         $result = $this->repository->getFilteredIncidentAlerts(['per_page' => 10]);
 
@@ -36,11 +39,13 @@ class IncidentAlertRepositoryTest extends TestCase
 
     public function test_create_incident_alert_creates_new_record(): void
     {
-        $incident = AiIncident::factory()->create();
+        $incident = AiIncident::factory()->create(['organization_id' => $this->organization->id]);
         $data = [
             'organization_id' => $this->organization->id,
             'ai_incident_id' => $incident->id,
-            'source_type' => 'kri',
+            'source_type' => AlertSourceType::KRI_THRESHOLD->value,
+            'alert_sensitivity' => AlertSeverity::MEDIUM->value,
+            'context' => 'Test alert context',
             'first_seen_at' => now()->subHour(),
         ];
 
@@ -48,36 +53,40 @@ class IncidentAlertRepositoryTest extends TestCase
 
         $this->assertInstanceOf(IncidentAlert::class, $result);
         $this->assertEquals($incident->id, $result->ai_incident_id);
-        $this->assertEquals('kri', $result->source_type);
+        $this->assertEquals(AlertSourceType::KRI_THRESHOLD->value, $result->source_type);
+        $this->assertEquals(AlertSeverity::MEDIUM->value, $result->alert_sensitivity);
         $this->assertDatabaseHas('incident_alerts', [
             'id' => $result->id,
             'ai_incident_id' => $incident->id,
-            'source_type' => 'kri',
+            'source_type' => AlertSourceType::KRI_THRESHOLD->value,
         ]);
     }
 
     public function test_create_incident_alert_with_all_fields(): void
     {
-        $incident = AiIncident::factory()->create();
+        $incident = AiIncident::factory()->create(['organization_id' => $this->organization->id]);
         $data = [
             'organization_id' => $this->organization->id,
             'ai_incident_id' => $incident->id,
-            'source_type' => 'monitoring_rule',
+            'source_type' => AlertSourceType::MONITORING_RULE->value,
+            'data_source_id' => null,
             'source_ref' => 'RULE-1234',
-            'rule_version' => 'v2.1.0',
+            'alert_sensitivity' => AlertSeverity::HIGH->value,
             'context' => 'Test context for alert',
             'first_seen_at' => now()->subHours(2),
             'last_seen_at' => now()->subHour(),
             'evidence_link' => 'https://example.com/evidence/123',
+            'auto_promote_incident' => true,
         ];
 
         $result = $this->repository->createIncidentAlert($data);
 
-        $this->assertEquals('monitoring_rule', $result->source_type);
+        $this->assertEquals(AlertSourceType::MONITORING_RULE->value, $result->source_type);
         $this->assertEquals('RULE-1234', $result->source_ref);
-        $this->assertEquals('v2.1.0', $result->rule_version);
+        $this->assertEquals(AlertSeverity::HIGH->value, $result->alert_sensitivity);
         $this->assertEquals('Test context for alert', $result->context);
         $this->assertEquals('https://example.com/evidence/123', $result->evidence_link);
+        $this->assertTrue($result->auto_promote_incident);
         $this->assertNotNull($result->first_seen_at);
         $this->assertNotNull($result->last_seen_at);
     }
@@ -85,52 +94,55 @@ class IncidentAlertRepositoryTest extends TestCase
     public function test_update_incident_alert_updates_existing_record(): void
     {
         $alert = IncidentAlert::factory()->create([
-            'source_type' => 'kri',
+            'organization_id' => $this->organization->id,
+            'source_type' => AlertSourceType::KRI_THRESHOLD->value,
             'source_ref' => 'OLD-REF',
         ]);
 
         $result = $this->repository->updateIncidentAlert($alert, [
-            'source_type' => 'monitoring_rule',
+            'source_type' => AlertSourceType::MONITORING_RULE->value,
             'source_ref' => 'NEW-REF',
         ]);
 
-        $this->assertEquals('monitoring_rule', $result->source_type);
+        $this->assertEquals(AlertSourceType::MONITORING_RULE->value, $result->source_type);
         $this->assertEquals('NEW-REF', $result->source_ref);
         $this->assertDatabaseHas('incident_alerts', [
             'id' => $alert->id,
-            'source_type' => 'monitoring_rule',
+            'source_type' => AlertSourceType::MONITORING_RULE->value,
             'source_ref' => 'NEW-REF',
         ]);
     }
 
     public function test_update_incident_alert_can_update_all_fields(): void
     {
-        $alert = IncidentAlert::factory()->create();
-        $newIncident = AiIncident::factory()->create();
+        $alert = IncidentAlert::factory()->create(['organization_id' => $this->organization->id]);
+        $newIncident = AiIncident::factory()->create(['organization_id' => $this->organization->id]);
 
         $updateData = [
             'ai_incident_id' => $newIncident->id,
-            'source_type' => 'human_report',
+            'source_type' => AlertSourceType::MANUAL_REPORT->value,
             'source_ref' => 'TICKET-9999',
-            'rule_version' => 'v3.0.0',
+            'alert_sensitivity' => AlertSeverity::CRITICAL->value,
             'context' => 'Updated context',
             'last_seen_at' => now(),
             'evidence_link' => 'https://example.com/new-evidence',
+            'auto_promote_incident' => false,
         ];
 
         $result = $this->repository->updateIncidentAlert($alert, $updateData);
 
         $this->assertEquals($newIncident->id, $result->ai_incident_id);
-        $this->assertEquals('human_report', $result->source_type);
+        $this->assertEquals(AlertSourceType::MANUAL_REPORT->value, $result->source_type);
         $this->assertEquals('TICKET-9999', $result->source_ref);
-        $this->assertEquals('v3.0.0', $result->rule_version);
+        $this->assertEquals(AlertSeverity::CRITICAL->value, $result->alert_sensitivity);
         $this->assertEquals('Updated context', $result->context);
         $this->assertEquals('https://example.com/new-evidence', $result->evidence_link);
+        $this->assertFalse($result->auto_promote_incident);
     }
 
     public function test_delete_incident_alert_removes_record(): void
     {
-        $alert = IncidentAlert::factory()->create();
+        $alert = IncidentAlert::factory()->create(['organization_id' => $this->organization->id]);
 
         $result = $this->repository->deleteIncidentAlert($alert);
 
@@ -140,7 +152,7 @@ class IncidentAlertRepositoryTest extends TestCase
 
     public function test_get_incident_alert_by_id_returns_alert(): void
     {
-        $alert = IncidentAlert::factory()->create();
+        $alert = IncidentAlert::factory()->create(['organization_id' => $this->organization->id]);
         $result = $this->repository->getIncidentAlertById($alert);
 
         $this->assertInstanceOf(IncidentAlert::class, $result);
@@ -149,14 +161,16 @@ class IncidentAlertRepositoryTest extends TestCase
 
     public function test_create_incident_alert_with_datetime_fields(): void
     {
-        $incident = AiIncident::factory()->create();
+        $incident = AiIncident::factory()->create(['organization_id' => $this->organization->id]);
         $firstSeen = now()->subHours(3);
         $lastSeen = now()->subHour();
 
         $data = [
             'organization_id' => $this->organization->id,
             'ai_incident_id' => $incident->id,
-            'source_type' => 'security_tool',
+            'source_type' => AlertSourceType::AUTOMATED_SCAN->value,
+            'alert_sensitivity' => AlertSeverity::LOW->value,
+            'context' => 'Automated scan context',
             'first_seen_at' => $firstSeen,
             'last_seen_at' => $lastSeen,
         ];
@@ -171,14 +185,23 @@ class IncidentAlertRepositoryTest extends TestCase
 
     public function test_create_incident_alert_with_all_source_types(): void
     {
-        $incident = AiIncident::factory()->create();
-        $sourceTypes = ['kri', 'monitoring_rule', 'human_report', 'vendor_notice', 'security_tool', 'other'];
+        $incident = AiIncident::factory()->create(['organization_id' => $this->organization->id]);
+        $sourceTypes = [
+            AlertSourceType::MONITORING_RULE->value,
+            AlertSourceType::KRI_THRESHOLD->value,
+            AlertSourceType::MANUAL_REPORT->value,
+            AlertSourceType::AUTOMATED_SCAN->value,
+            AlertSourceType::USER_COMPLAINT->value,
+            AlertSourceType::EXTERNAL_REPORT->value,
+        ];
 
         foreach ($sourceTypes as $sourceType) {
             $data = [
                 'organization_id' => $this->organization->id,
                 'ai_incident_id' => $incident->id,
                 'source_type' => $sourceType,
+                'alert_sensitivity' => AlertSeverity::MEDIUM->value,
+                'context' => "Alert context for {$sourceType}",
                 'first_seen_at' => now(),
             ];
 
@@ -190,19 +213,45 @@ class IncidentAlertRepositoryTest extends TestCase
 
     public function test_paginated_alerts_loads_ai_incident_relationship(): void
     {
-        IncidentAlert::factory()->count(3)->create();
+        IncidentAlert::factory()->count(3)->create(['organization_id' => $this->organization->id]);
 
-        $result = $this->repository->getFilteredIncidentAlerts();
+        $result = $this->repository->getFilteredIncidentAlerts(['organization_id' => $this->organization->id]);
 
         $this->assertTrue($result->items()[0]->relationLoaded('aiIncident'));
     }
 
     public function test_get_by_id_loads_ai_incident_relationship(): void
     {
-        $alert = IncidentAlert::factory()->create();
+        $alert = IncidentAlert::factory()->create(['organization_id' => $this->organization->id]);
 
         $result = $this->repository->getIncidentAlertById($alert);
 
         $this->assertTrue($result->relationLoaded('aiIncident'));
+    }
+
+    public function test_create_incident_alert_with_all_severities(): void
+    {
+        $incident = AiIncident::factory()->create(['organization_id' => $this->organization->id]);
+        $severities = [
+            AlertSeverity::LOW->value,
+            AlertSeverity::MEDIUM->value,
+            AlertSeverity::HIGH->value,
+            AlertSeverity::CRITICAL->value,
+        ];
+
+        foreach ($severities as $severity) {
+            $data = [
+                'organization_id' => $this->organization->id,
+                'ai_incident_id' => $incident->id,
+                'source_type' => AlertSourceType::MONITORING_RULE->value,
+                'alert_sensitivity' => $severity,
+                'context' => "Alert with {$severity} severity",
+                'first_seen_at' => now(),
+            ];
+
+            $result = $this->repository->createIncidentAlert($data);
+
+            $this->assertEquals($severity, $result->alert_sensitivity);
+        }
     }
 }


### PR DESCRIPTION
- Added AlertSeverity enum with LOW, MEDIUM, HIGH, and CRITICAL cases.
- Modified AlertSourceType enum to include KRI_THRESHOLD, MANUAL_REPORT, AUTOMATED_SCAN, USER_COMPLAINT, and EXTERNAL_REPORT.
- Updated IncidentAlert model to include data_source_id, alert_sensitivity, and auto_promote_incident fields.
- Removed rule_version from IncidentAlert model and migration.
- Enhanced StoreIncidentAlertRequest and UpdateIncidentAlertRequest to validate new fields.
- Updated IncidentAlertResource to include new fields in the response.
- Modified IncidentAlertFactory to support new alert severities and source types.
- Created migration to modify incident_alerts table structure.
- Updated IncidentAlertController and its tests to handle new fields and enums.
- Enhanced tests for IncidentAlertRepository to validate new alert severities and source types.